### PR TITLE
Updates JSON output to include catalog information to fix #7

### DIFF
--- a/ckanext/dcat/commands.py
+++ b/ckanext/dcat/commands.py
@@ -45,11 +45,22 @@ class GenerateStaticDCATCommand(p.toolkit.CkanCommand):
         data_dict = {'page': 0}
 
         with open(output, 'w') as f:
-            f.write(u"[")
+            f.write(u'{')
+            try:
+                # Generate the dcat:catalog elements for the result.
+                catalog = p.toolkit.get_action('dcat_catalog_info')({},
+                                                                data_dict)
+            except p.toolkit.ValidationError, e:
+                p.toolkit.abort(409, str(e))
+
+            header = json.dumps(catalog)[1:-1]
+            f.write(header)
+            f.write(u',"dataset": [')
 
             while True:
+                data_dict['page'] = data_dict['page'] + 1
+
                 try:
-                    data_dict['page'] = data_dict['page'] + 1
                     datasets = \
                         p.toolkit.get_action('dcat_datasets_list')({},
                                                                    data_dict)
@@ -61,6 +72,6 @@ class GenerateStaticDCATCommand(p.toolkit.CkanCommand):
                     break
 
                 for dataset in datasets:
-                    f.write(json.dumps(dataset))
+                    json.dump(dataset, f)
 
-            f.write(u"]")
+            f.write(u"]}")

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from pylons import config
 from dateutil.parser import parse as dateutil_parse
@@ -7,10 +8,14 @@ from ckan import plugins as p
 
 if p.toolkit.check_ckan_version(min_version='2.1'):
     BaseController = p.toolkit.BaseController
+    response = p.toolkit.response
 else:
     from ckan.lib.base import BaseController
+    from pylons import response
 
 import ckanext.dcat.converters as converters
+
+log = logging.getLogger(__name__)
 
 
 class DCATJSONInterface(p.SingletonPlugin):
@@ -31,6 +36,8 @@ class DCATJSONInterface(p.SingletonPlugin):
     def get_actions(self):
         return {
             'dcat_datasets_list': dcat_datasets_list,
+            'dcat_catalog_info': dcat_catalog_info,
+            'dcat_latest_revision': dcat_latest_revision
         }
 
 
@@ -44,17 +51,37 @@ class DCATController(BaseController):
         }
 
         try:
+            # Generate the dcat:catalog elements for the result.
+            catalog = p.toolkit.get_action('dcat_catalog_info')({},
+                                                            data_dict)
+        except p.toolkit.ValidationError, e:
+            p.toolkit.abort(409, str(e))
+
+        try:
             datasets = p.toolkit.get_action('dcat_datasets_list')({},
                                                                   data_dict)
         except p.toolkit.ValidationError, e:
             p.toolkit.abort(409, str(e))
 
-        content = json.dumps(datasets)
+        # We don't want to ever use json.dumps as it means we have the
+        # original dicts AND the JSON string in memory. Ideally we'd use
+        # json.dump(response, datasets) which will write straight to the
+        # stream, but then we'd lose the Content-length
+        catalog["dataset"] = datasets
+        content = json.dumps(catalog)
 
-        p.toolkit.response.headers['Content-Type'] = 'application/json'
-        p.toolkit.response.headers['Content-Length'] = len(content)
+        response.headers['Content-Type'] = 'application/json'
+        response.headers['Content-Length'] = len(content)
 
         return content
+
+
+def dcat_latest_revision(context, data_dict):
+    import ckan.model as model
+    rev = model.Session.query(model.Revision).order_by("timestamp desc").first()
+    if rev:
+        return rev.timestamp.isoformat()
+    return ''
 
 
 def dcat_datasets_list(context, data_dict):
@@ -63,6 +90,31 @@ def dcat_datasets_list(context, data_dict):
 
     return [converters.ckan_to_dcat(ckan_dataset)
             for ckan_dataset in ckan_datasets]
+
+
+def dcat_catalog_info(context, data_dict):
+    """
+    Returns a dict containing the fields needed for the catalog element
+
+    Some fields are missing:
+        'issued' is missing as now obvious way to determine when the
+        catalog went live.
+        'license' is missing as it isn't clear that the catalog has a
+        license.
+    """
+    try:
+        revision = p.toolkit.get_action('dcat_latest_revision')({},{})
+    except Exception, e:
+        log.exception(e)
+        revision = ''
+
+    return {
+        'title': config.get('ckan.site_title', 'CKAN'),
+        'description': config.get('ckan.site_description', ''),
+        'homepage': config.get('ckan.site_url', ''),
+        'language': config.get('ckan.locale_default', 'en'),
+        'modified': revision,
+    }
 
 
 def _search_ckan_datasets(context, data_dict):
@@ -88,7 +140,6 @@ def _search_ckan_datasets(context, data_dict):
                 'Wrong modified date format. Use ISO-8601 format')
 
     search_data_dict = {
-        'q': '*:*',
         'fq': 'dataset_type:dataset',
         'rows': n,
         'start': n * (page - 1),


### PR DESCRIPTION
Adding catalog metadata to the JSON output so that it more closely resembles https://github.com/okfn/ckanext-dcat/blob/master/examples/catalog.json

Also removes the 'q' element from the package_search as it is un-necessary (and *:* doesn't work for me).