### PR TITLE
Allow rdf harvester after_download to run if there is no content

### DIFF
--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -145,9 +145,6 @@ class DCATRDFHarvester(DCATHarvester):
 
         content = self._get_content(url, harvest_job, 1)
 
-        if not content:
-            return False
-
         # TODO: store content?
         for harvester in p.PluginImplementations(IDCATRDFHarvester):
             content, after_download_errors = harvester.after_download(content, harvest_job)
@@ -155,8 +152,8 @@ class DCATRDFHarvester(DCATHarvester):
             for error_msg in after_download_errors:
                 self._save_gather_error(error_msg, harvest_job)
 
-            if not content:
-                return False
+        if not content:
+            return False
 
         # TODO: profiles conf
         parser = RDFParser()


### PR DESCRIPTION
The after_download hook is not run if the content is empty (some
sites return no content and status code 200 if a site doesn't
exist).

If the after_download hook for example does some validation on the
content and returns the validation errors via gather errors, then
returning before after_download is called means the validation will
not be run and it may look like everything validates just fine
which obviously it shouldn't.

The return based on no content should then happen after the
after_download hooks have been called for all plugin
implementations.