### PR TITLE
RDF DCAT Harvester also supports non-XML formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,11 @@ to allow automatic import of datasets from remote sources. To enable the RDF har
 The harvester will download the remote file, extract all datasets using the parser and create or update actual CKAN datasets based on that.
 It will also handle deletions, ie if a dataset is not present any more in the DCAT dump anymore it will get deleted from CKAN.
 
-*TODO*: configure formats and profiles.
+The harvester will look at the `content-type` HTTP header field to determine the used RDF format. Any format understood by the [RDFLib](https://rdflib.readthedocs.org/en/stable/plugin_parsers.html) library can be parsed. It is possible to override this functionality and provide a specific format using the harvester configuration. This is useful when the server does not return the correct `content-type` or when harvesting a file on the local file system without a proper extension. The harvester configuration is a JSON object that you fill into the harvester configuration form field.
+
+    {"rdf_format":"text/turtle"}
+
+*TODO*: configure profiles.
 
 ### Extending the RDF harvester
 

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -80,7 +80,9 @@ class DCATHarvester(HarvesterBase):
                     self._save_gather_error('Remote file is too big.', harvest_job)
                     return None, None
 
-            _content_format = _content_format or r.headers.get('content-type').split(";", 1)[0]
+            if _content_format is None and r.headers.get('content-type'):
+                _content_format = r.headers.get('content-type').split(";", 1)[0]
+
             return content, _content_format
 
         except requests.exceptions.HTTPError, error:

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -13,6 +13,7 @@ from ckan import model
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
+from ckanext.dcat.processors import RDFParserException, RDFParser
 
 
 log = logging.getLogger(__name__)
@@ -26,6 +27,21 @@ class DCATHarvester(HarvesterBase):
     force_import = False
 
     _user_name = None
+
+    def validate_config(self, source_config):
+        if not source_config:
+            return source_config
+
+        source_config_obj = json.loads(source_config)
+        if 'rdf_format' in source_config_obj:
+            rdf_format = source_config_obj['rdf_format']
+            if not isinstance(rdf_format, basestring):
+                raise ValueError('rdf_format must be a string')
+            supported_formats = RDFParser().supported_formats()
+            if rdf_format not in supported_formats:
+                raise ValueError('rdf_format should be one of: ' + ", ".join(supported_formats))
+
+        return source_config
 
     def _get_content(self, url, harvest_job, page=1):
         _content_format = None

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -127,6 +127,21 @@ class DCATRDFHarvester(DCATHarvester):
 
         return object_ids
 
+    def validate_config(self, source_config):
+        if not source_config:
+            return source_config
+
+        source_config_obj = json.loads(source_config)
+        if 'rdf_format' in source_config_obj:
+            rdf_format = source_config_obj['rdf_format']
+            if not isinstance(rdf_format, basestring):
+                raise ValueError('rdf_format must be a string')
+            supported_formats = RDFParser().supported_formats()
+            if rdf_format not in supported_formats:
+                raise ValueError('rdf_format should be one of: ' + ", ".join(supported_formats))
+
+        return source_config
+
     def gather_stage(self, harvest_job):
 
         log.debug('In DCATRDFHarvester gather_stage')
@@ -143,7 +158,10 @@ class DCATRDFHarvester(DCATHarvester):
             if not url:
                 return False
 
-        content, content_format = self._get_content(url, harvest_job, 1)
+        rdf_format = None
+        if harvest_job.source.config:
+            rdf_format = json.loads(harvest_job.source.config).get("rdf_format")
+        content, rdf_format = self._get_content_and_type(url, harvest_job, 1, content_type=rdf_format)
 
         # TODO: store content?
         for harvester in p.PluginImplementations(IDCATRDFHarvester):
@@ -159,7 +177,7 @@ class DCATRDFHarvester(DCATHarvester):
         parser = RDFParser()
 
         try:
-            parser.parse(content, _format=content_format)
+            parser.parse(content, _format=rdf_format)
         except RDFParserException, e:
             self._save_gather_error('Error parsing the RDF file: {0}'.format(e), harvest_job)
             return False

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -143,7 +143,7 @@ class DCATRDFHarvester(DCATHarvester):
             if not url:
                 return False
 
-        content = self._get_content(url, harvest_job, 1)
+        content, content_format = self._get_content(url, harvest_job, 1)
 
         # TODO: store content?
         for harvester in p.PluginImplementations(IDCATRDFHarvester):
@@ -157,9 +157,9 @@ class DCATRDFHarvester(DCATHarvester):
 
         # TODO: profiles conf
         parser = RDFParser()
-        # TODO: format conf
+
         try:
-            parser.parse(content)
+            parser.parse(content, _format=content_format)
         except RDFParserException, e:
             self._save_gather_error('Error parsing the RDF file: {0}'.format(e), harvest_job)
             return False

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -130,6 +130,7 @@ class RDFParser(RDFProcessor):
         # Apparently there is no single way of catching exceptions from all
         # rdflib parsers at once, so if you use a new one and the parsing
         # exceptions are not cached, add them here.
+        # PluginException indicates that an unknown format was passed.
         except (SyntaxError, xml.sax.SAXParseException, rdflib.plugin.PluginException), e:
 
             raise RDFParserException(e)

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -7,6 +7,7 @@ from pkg_resources import iter_entry_points
 from pylons import config
 
 import rdflib
+import rdflib.parser
 from rdflib import URIRef, BNode, Literal
 from rdflib.namespace import Namespace, RDF
 
@@ -134,6 +135,12 @@ class RDFParser(RDFProcessor):
         except (SyntaxError, xml.sax.SAXParseException, rdflib.plugin.PluginException), e:
 
             raise RDFParserException(e)
+
+    def supported_formats(self):
+        '''
+        Returns a list of all formats supported by this processor.
+        '''
+        return sorted([plugin.name for plugin in rdflib.plugin.plugins(kind=rdflib.parser.Parser)])
 
     def datasets(self):
         '''

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -130,7 +130,7 @@ class RDFParser(RDFProcessor):
         # Apparently there is no single way of catching exceptions from all
         # rdflib parsers at once, so if you use a new one and the parsing
         # exceptions are not cached, add them here.
-        except (SyntaxError, xml.sax.SAXParseException), e:
+        except (SyntaxError, xml.sax.SAXParseException, rdflib.plugin.PluginException), e:
 
             raise RDFParserException(e)
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -22,20 +22,20 @@ eq_ = nose.tools.eq_
 
 # Start monkey-patch
 
-original_get_content = DCATRDFHarvester._get_content
+original_get_content_and_type = DCATRDFHarvester._get_content_and_type
 
 
-def _patched_get_content(self, url, harvest_job, page=1):
+def _patched_get_content_and_type(self, url, harvest_job, page=1, content_type=None):
 
     httpretty.enable()
 
-    value1, value2 = original_get_content(self, url, harvest_job, page)
+    value1, value2 = original_get_content_and_type(self, url, harvest_job, page, content_type)
 
     httpretty.disable()
 
     return value1, value2
 
-DCATRDFHarvester._get_content = _patched_get_content
+DCATRDFHarvester._get_content_and_type = _patched_get_content_and_type
 
 # End monkey-patch
 
@@ -737,7 +737,7 @@ class TestDCATRDFHarvester(object):
     def test_does_not_validate_incorrect_config(self):
         harvester = DCATRDFHarvester()
 
-        for config in ['invalid', '{invalid}', '{"rdf_format":"invalid"}']:
+        for config in ['invalid', '{invalid}', '{rdf_format:invalid}']:
             try:
                 harvester.validate_config(config)
                 assert False

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -29,11 +29,11 @@ def _patched_get_content(self, url, harvest_job, page=1):
 
     httpretty.enable()
 
-    value = original_get_content(self, url, harvest_job, page)
+    value1, value2 = original_get_content(self, url, harvest_job, page)
 
     httpretty.disable()
 
-    return value
+    return value1, value2
 
 DCATRDFHarvester._get_content = _patched_get_content
 
@@ -148,10 +148,10 @@ class FunctionalHarvestTest(object):
         cls.fetch_consumer = queue.get_consumer('ckan.harvest.fetch.test',
                                                 'harvest_object_id')
 
-        cls.mock_url = 'http://some.dcat.file.rdf'
-
         # Minimal remote RDF file
-        cls.remote_file = '''<?xml version="1.0" encoding="utf-8" ?>
+        cls.rdf_mock_url = 'http://some.dcat.file.rdf'
+        cls.rdf_content_type = 'application/rdf+xml'
+        cls.rdf_content = '''<?xml version="1.0" encoding="utf-8" ?>
         <rdf:RDF
          xmlns:dct="http://purl.org/dc/terms/"
          xmlns:dcat="http://www.w3.org/ns/dcat#"
@@ -171,6 +171,62 @@ class FunctionalHarvestTest(object):
         </dcat:Catalog>
         </rdf:RDF>
         '''
+        cls.rdf_remote_file_small = '''<?xml version="1.0" encoding="utf-8" ?>
+        <rdf:RDF
+         xmlns:dct="http://purl.org/dc/terms/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <dcat:Catalog rdf:about="https://data.some.org/catalog">
+          <dcat:dataset>
+            <dcat:Dataset rdf:about="https://data.some.org/catalog/datasets/1">
+              <dct:title>Example dataset 1</dct:title>
+            </dcat:Dataset>
+          </dcat:dataset>
+        </dcat:Catalog>
+        </rdf:RDF>
+        '''
+        cls.rdf_remote_file_invalid = '''<?xml version="1.0" encoding="utf-8" ?>
+        <rdf:RDF
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <dcat:Catalog
+        </rdf:RDF>
+        '''
+
+        #Minimal remote turtle file
+        cls.ttl_mock_url = 'http://some.dcat.file.ttl'
+        cls.ttl_content_type = 'text/turtle'
+        cls.ttl_content = '''@prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix dc: <http://purl.org/dc/terms/> .
+        <https://data.some.org/catalog>
+          a dcat:Catalog ;
+          dcat:dataset <https://data.some.org/catalog/datasets/1>, <https://data.some.org/catalog/datasets/2> .
+        <https://data.some.org/catalog/datasets/1>
+          a dcat:Dataset ;
+          dc:title "Example dataset 1" .
+        <https://data.some.org/catalog/datasets/2>
+          a dcat:Dataset ;
+          dc:title "Example dataset 2" .
+          '''
+        cls.ttl_remote_file_small = '''@prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix dc: <http://purl.org/dc/terms/> .
+        <https://data.some.org/catalog>
+          a dcat:Catalog ;
+          dcat:dataset <https://data.some.org/catalog/datasets/1>, <https://data.some.org/catalog/datasets/2> .
+        <https://data.some.org/catalog/datasets/1>
+          a dcat:Dataset ;
+          dc:title "Example dataset 1" .
+          '''
+        cls.ttl_remote_file_invalid =  '''@prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix dc: <http://purl.org/dc/terms/> .
+        <https://data.some.org/catalog>
+          a dcat:Catalog ;
+        <https://data.some.org/catalog/datasets/1>
+          a dcat:Dataset ;
+          dc:title "Example dataset 1" .
+          '''
+
 
     def setup(self):
 
@@ -182,12 +238,12 @@ class FunctionalHarvestTest(object):
     def teardown(cls):
         h.reset_db()
 
-    def _create_harvest_source(self, **kwargs):
+    def _create_harvest_source(self, mock_url, **kwargs):
 
         source_dict = {
             'title': 'Test RDF DCAT Source',
             'name': 'test-rdf-dcat-source',
-            'url': self.mock_url,
+            'url': mock_url,
             'source_type': 'dcat_rdf',
         }
 
@@ -261,18 +317,37 @@ class FunctionalHarvestTest(object):
 
 class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
-    def test_harvest_create(self):
+    def test_harvest_create_rdf(self):
+
+        self._test_harvest_create(self.rdf_mock_url,
+                                  self.rdf_content,
+                                  self.rdf_content_type)
+
+    def test_harvest_create_ttl(self):
+
+        self._test_harvest_create(self.ttl_mock_url,
+                                  self.ttl_content,
+                                  self.ttl_content_type)
+
+    def test_harvest_create_with_config_content_Type(self):
+
+        self._test_harvest_create(self.ttl_mock_url,
+                                  self.ttl_content,
+                                  'text/plain',
+                                  config='{"rdf_format":"text/turtle"}')
+
+    def _test_harvest_create(self, url, content, content_type, **kwargs):
 
         # Mock the GET request to get the file
-        httpretty.register_uri(httpretty.GET, self.mock_url,
-                               body=self.remote_file)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=content, content_type=content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
-        httpretty.register_uri(httpretty.HEAD, self.mock_url,
-                               status=405)
+        httpretty.register_uri(httpretty.HEAD, url,
+                               status=405, content_type=content_type)
 
-        harvest_source = self._create_harvest_source()
+        harvest_source = self._create_harvest_source(url, **kwargs)
 
         self._run_full_job(harvest_source['id'], num_objects=2)
 
@@ -286,18 +361,29 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
             assert result['title'] in ('Example dataset 1',
                                        'Example dataset 2')
 
-    def test_harvest_update(self):
+    def test_harvest_update_rdf(self):
 
+        self._test_harvest_update(self.rdf_mock_url,
+                                  self.rdf_content,
+                                  self.rdf_content_type)
+
+    def test_harvest_update_ttl(self):
+
+        self._test_harvest_update(self.ttl_mock_url,
+                                  self.ttl_content,
+                                  self.ttl_content_type)
+
+    def _test_harvest_update(self, url, content, content_type):
         # Mock the GET request to get the file
-        httpretty.register_uri(httpretty.GET, self.mock_url,
-                               body=self.remote_file)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=content, content_type=content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
-        httpretty.register_uri(httpretty.HEAD, self.mock_url,
-                               status=405)
+        httpretty.register_uri(httpretty.HEAD, url,
+                               status=405, content_type=content_type)
 
-        harvest_source = self._create_harvest_source()
+        harvest_source = self._create_harvest_source(url)
 
         # First run, will create two datasets as previously tested
         self._run_full_job(harvest_source['id'], num_objects=2)
@@ -306,10 +392,10 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         self._run_jobs()
 
         # Mock an update in the remote file
-        new_file = self.remote_file.replace('Example dataset 1',
-                                            'Example dataset 1 (updated)')
-        httpretty.register_uri(httpretty.GET, self.mock_url,
-                               body=new_file)
+        new_file = content.replace('Example dataset 1',
+                                   'Example dataset 1 (updated)')
+        httpretty.register_uri(httpretty.GET, url,
+                               body=new_file, content_type=content_type)
 
         # Run a second job
         self._run_full_job(harvest_source['id'], num_objects=2)
@@ -325,18 +411,32 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
             assert result['title'] in ('Example dataset 1 (updated)',
                                        'Example dataset 2')
 
-    def test_harvest_delete(self):
+    def test_harvest_delete_rdf(self):
+
+        self._test_harvest_delete(self.rdf_mock_url,
+                                  self.rdf_content,
+                                  self.rdf_remote_file_small,
+                                  self.rdf_content_type)
+
+    def test_harvest_delete_ttl(self):
+
+        self._test_harvest_delete(self.ttl_mock_url,
+                                  self.ttl_content,
+                                  self.ttl_remote_file_small,
+                                  self.ttl_content_type)
+
+    def _test_harvest_delete(self, url, content, content_small, content_type):
 
         # Mock the GET request to get the file
-        httpretty.register_uri(httpretty.GET, self.mock_url,
-                               body=self.remote_file)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=content, content_type=content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
-        httpretty.register_uri(httpretty.HEAD, self.mock_url,
-                               status=405)
+        httpretty.register_uri(httpretty.HEAD, url,
+                               status=405, content_type=content_type)
 
-        harvest_source = self._create_harvest_source()
+        harvest_source = self._create_harvest_source(url)
 
         # First run, will create two datasets as previously tested
         self._run_full_job(harvest_source['id'], num_objects=2)
@@ -345,23 +445,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         self._run_jobs()
 
         # Mock a deletion in the remote file
-        new_file = '''<?xml version="1.0" encoding="utf-8" ?>
-        <rdf:RDF
-         xmlns:dct="http://purl.org/dc/terms/"
-         xmlns:dcat="http://www.w3.org/ns/dcat#"
-         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-        <dcat:Catalog rdf:about="https://data.some.org/catalog">
-          <dcat:dataset>
-            <dcat:Dataset rdf:about="https://data.some.org/catalog/datasets/1">
-              <dct:title>Example dataset 1</dct:title>
-            </dcat:Dataset>
-          </dcat:dataset>
-        </dcat:Catalog>
-        </rdf:RDF>
-        '''
-        httpretty.register_uri(httpretty.GET, self.mock_url,
-                               body=new_file)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=content_small, content_type=content_type)
 
         # Run a second job
         self._run_full_job(harvest_source['id'], num_objects=2)
@@ -374,26 +459,30 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
         eq_(results['results'][0]['title'], 'Example dataset 1')
 
-    def test_harvest_bad_format(self):
+    def test_harvest_bad_format_rdf(self):
 
-        bad_format_file = '''<?xml version="1.0" encoding="utf-8" ?>
-        <rdf:RDF
-         xmlns:dcat="http://www.w3.org/ns/dcat#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-        <dcat:Catalog
-        </rdf:RDF>
-        '''
+        self._test_harvest_bad_format(self.rdf_mock_url,
+                                      self.rdf_remote_file_invalid,
+                                      self.rdf_content_type)
+
+    def test_harvest_bad_format_ttl(self):
+
+        self._test_harvest_bad_format(self.ttl_mock_url,
+                                      self.ttl_remote_file_invalid,
+                                      self.ttl_content_type)
+
+    def _test_harvest_bad_format(self, url, bad_content, content_type):
 
         # Mock the GET request to get the file
-        httpretty.register_uri(httpretty.GET, self.mock_url,
-                               body=bad_format_file)
+        httpretty.register_uri(httpretty.GET, url,
+                               body=bad_content, content_type=content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
-        httpretty.register_uri(httpretty.HEAD, self.mock_url,
-                               status=405)
+        httpretty.register_uri(httpretty.HEAD, url,
+                               status=405, content_type=content_type)
 
-        harvest_source = self._create_harvest_source()
+        harvest_source = self._create_harvest_source(url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)
@@ -444,7 +533,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         plugin = p.get_plugin('test_rdf_harvester')
 
-        harvest_source = self._create_harvest_source()
+        harvest_source = self._create_harvest_source(self.rdf_mock_url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)
@@ -459,14 +548,16 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         # Mock the GET request to get the file
         httpretty.register_uri(httpretty.GET, source_url,
-                               body=self.remote_file)
+                               body=self.rdf_content,
+                               content_type=self.rdf_content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
         httpretty.register_uri(httpretty.HEAD, source_url,
-                               status=405)
+                               status=405,
+                               content_type=self.rdf_content_type)
 
-        harvest_source = self._create_harvest_source(url=source_url)
+        harvest_source = self._create_harvest_source(source_url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)
@@ -500,14 +591,16 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         # Mock the GET request to get the file
         httpretty.register_uri(httpretty.GET, source_url,
-                               body=self.remote_file)
+                               body=self.rdf_content,
+                               content_type=self.rdf_content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
         httpretty.register_uri(httpretty.HEAD, source_url,
-                               status=405)
+                               status=405,
+                               content_type=self.rdf_content_type)
 
-        harvest_source = self._create_harvest_source(url=source_url)
+        harvest_source = self._create_harvest_source(source_url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)
@@ -534,14 +627,14 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         plugin = p.get_plugin('test_rdf_harvester')
 
         # Mock the GET request to get the file
-        httpretty.register_uri(httpretty.GET, self.mock_url)
+        httpretty.register_uri(httpretty.GET, self.rdf_mock_url)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
-        httpretty.register_uri(httpretty.HEAD, self.mock_url,
+        httpretty.register_uri(httpretty.HEAD, self.rdf_mock_url,
                                status=405)
 
-        harvest_source = self._create_harvest_source()
+        harvest_source = self._create_harvest_source(self.rdf_mock_url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)
@@ -556,14 +649,16 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         # Mock the GET request to get the file
         httpretty.register_uri(httpretty.GET, source_url,
-                               body='return.empty.content')
+                               body='return.empty.content',
+                               content_type=self.rdf_content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
         httpretty.register_uri(httpretty.HEAD, source_url,
-                               status=405)
+                               status=405,
+                               content_type=self.rdf_content_type)
 
-        harvest_source = self._create_harvest_source(url=source_url)
+        harvest_source = self._create_harvest_source(source_url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)
@@ -598,14 +693,16 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         # Mock the GET request to get the file
         httpretty.register_uri(httpretty.GET, source_url,
-                               body='return.errors')
+                               body='return.errors',
+                               content_type=self.rdf_content_type)
 
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
         httpretty.register_uri(httpretty.HEAD, source_url,
-                               status=405)
+                               status=405,
+                               content_type=self.rdf_content_type)
 
-        harvest_source = self._create_harvest_source(url=source_url)
+        harvest_source = self._create_harvest_source(source_url)
         self._create_harvest_job(harvest_source['id'])
         self._run_jobs(harvest_source['id'])
         self._gather_queue(1)

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -726,6 +726,25 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         eq_('Error 2', last_job_status['gather_error_summary'][1][0])
 
 
+class TestDCATRDFHarvester(object):
+
+    def test_validates_correct_config(self):
+        harvester = DCATRDFHarvester()
+
+        for config in ['{}', '{"rdf_format":"text/turtle"}']:
+            eq_(config, harvester.validate_config(config))
+
+    def test_does_not_validate_incorrect_config(self):
+        harvester = DCATRDFHarvester()
+
+        for config in ['invalid', '{invalid}', '{"rdf_format":"invalid"}']:
+            try:
+                harvester.validate_config(config)
+                assert False
+            except ValueError:
+                assert True
+
+
 class TestIDCATRDFHarvester(object):
 
     def test_before_download(self):


### PR DESCRIPTION
I have adjusted the DCAT parsing using RDFLib to support other RDF formats, such as turtle or n3. Docs and tests have been updated as well.