### PR TITLE
Fix a crashing NotFound

### DIFF
--- a/ckanext/dcat/controllers.py
+++ b/ckanext/dcat/controllers.py
@@ -55,8 +55,14 @@ class DCATController(BaseController):
 
         toolkit.response.headers.update(
             {'Content-type': CONTENT_TYPES[_format]})
-        return toolkit.get_action('dcat_dataset_show')({}, {'id': _id,
-                                                            'format': _format})
+
+        try:
+            result = toolkit.get_action('dcat_dataset_show')({}, {'id': _id,
+                'format': _format})
+        except toolkit.ObjectNotFound:
+            toolkit.abort(404)
+
+        return result
 
     def dcat_json(self):
 

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -180,6 +180,13 @@ class TestEndpoints(helpers.FunctionalTestBase):
         eq_(dcat_dataset['title'], dataset['title'])
         eq_(dcat_dataset['notes'], dataset['notes'])
 
+    def test_dataset_not_found(self):
+        import uuid
+
+        url = url_for('dcat_dataset', _id=str(uuid.uuid4()), _format='n3')
+        app = self._get_test_app()
+        app.get(url, status=404)
+
     def test_catalog_default(self):
 
         for i in xrange(4):


### PR DESCRIPTION
The controller was calling an action function that might raise a NotFound exception from package_show deeper down the stack.

This provides a fix, and a test that requests a new UUID (so that it will be not found) and we expect a 404.

Fixes #40 