### PR TITLE
Use https URL for geomet dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 rdflib==4.1.2
 rdflib-jsonld==0.2
-git+git://github.com/geomet/geomet.git
+git+https://github.com/geomet/geomet.git


### PR DESCRIPTION
https:// URL has more chance to be reachable that git:// one, e.g., when
behind a firewall.