### PR TITLE
Add a gather error instead of log.error

### DIFF
--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -201,7 +201,8 @@ class DCATRDFHarvester(DCATHarvester):
             guid = self._get_guid(dataset)
 
             if not guid:
-                log.error('Could not get a unique identifier for dataset: {0}'.format(dataset))
+                self._save_gather_error('Could not get a unique identifier for dataset: {0}'.format(dataset),
+                                        harvest_job)
                 continue
 
             dataset['extras'].append({'key': 'guid', 'value': guid})


### PR DESCRIPTION
A missing guid is a clear indicator of a source that is broken.
These errors should be visible and not buried in an error log.