### PR TITLE
Add MANIFEST.in to ensure i18n files are include in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include ckanext/dcat/i18n *


### PR DESCRIPTION
Without this, if you install the package not in 'editable' (ie,`setup.py install` instead of `setup.py develop` or `pip install -e`) mode, the i18n files are not installed, and the extension cannot be enabled