### PR TITLE
Retrieve license information from distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ This mapping is compatible with the [DCAT-AP v1.1](https://joinup.ec.europa.eu/a
 | dcat:Distribution | dct:description        | resource:description                      |                                | text      |                                                                                                                                                               |
 | dcat:Distribution | dcat:mediaType         | resource:mimetype                         |                                | text      |                                                                                                                                                               |
 | dcat:Distribution | dct:format             | resource:format                           |                                | text      | This is likely to require extra logic to accommodate how CKAN deals with formats (eg ckan/ckanext-dcat#18)                                                    |
-| dcat:Distribution | dct:license            | resource:license                          |                                | text      | Note that on the CKAN model, license is at the dataset level                                                                                                  |
+| dcat:Distribution | dct:license            | resource:license                          |                                | text      | See note about dataset license                                                                                                                                |
 | dcat:Distribution | adms:status            | resource:status                           |                                | text      |                                                                                                                                                               |
 | dcat:Distribution | dcat:byteSize          | resource:size                             |                                | number    |                                                                                                                                                               |
 | dcat:Distribution | dct:issued             | resource:issued                           |                                | text      |                                                                                                                                                               |
@@ -457,6 +457,14 @@ This mapping is compatible with the [DCAT-AP v1.1](https://joinup.ec.europa.eu/a
             </dct:Location>
         </dct:spatial>
         ```
+
+*  On the CKAN model, license is at the dataset level whereas in DCAT model it
+   is at distributions level. By default the RDF parser will try to find a
+   distribution with a license that matches one of those registered in CKAN
+   and attach this license to the dataset. The first matching distribution's
+   license is used, meaning that any discrepancy accross distributions license
+   will not be accounted for. This behavior can be customized by overridding the
+   `_license` method on a custom profile.
 
 
 ## RDF DCAT Parser

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -67,6 +67,10 @@ class RDFProfile(object):
 
         self.compatibility_mode = compatibility_mode
 
+        # Cache for mappings of licenses URL/title to ID built when needed in
+        # _license().
+        self._licenceregister_cache = None
+
     def _datasets(self):
         '''
         Generator that returns all DCAT datasets on the graph
@@ -318,11 +322,15 @@ class RDFProfile(object):
         that if distributions have different licenses we'll only get the first
         one.
         '''
-        license_uri2id = {}
-        license_title2id = {}
-        for license_id, license in LicenseRegister().items():
-            license_uri2id[license.url] = license_id
-            license_title2id[license.title] = license_id
+        if self._licenceregister_cache is not None:
+            license_uri2id, license_title2id = self._licenceregister_cache
+        else:
+            license_uri2id = {}
+            license_title2id = {}
+            for license_id, license in LicenseRegister().items():
+                license_uri2id[license.url] = license_id
+                license_title2id[license.title] = license_id
+            self._licenceregister_cache = license_uri2id, license_title2id
 
         for distribution in self._distributions(dataset_ref):
             # If distribution has a license, attach it to the dataset

--- a/examples/dataset.rdf
+++ b/examples/dataset.rdf
@@ -76,7 +76,7 @@
             <dct:description>A longer description</dct:description>
             <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2012-05-11</dct:issued>
             <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-05-01T00:04:06</dct:modified>
-            <dct:license rdf:resource="http://creativecommons.org/licenses/by/3.0/"/>
+            <dct:license rdf:resource="http://creativecommons.org/licenses/by-nc/2.0/"/>
             <dct:rights>Some statement about rights</dct:rights>
             <adms:status rdf:resource="http://purl.org/adms/status/Completed"/>
             <dcat:accessURL rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.bgs.ac.uk/gbase/geochemcd/home.html</dcat:accessURL>


### PR DESCRIPTION
Closes #42

Following a recent [thread](https://lists.okfn.org/pipermail/ckan-dev/2017-February/010794.html) on the mailing list.
We have been using this patch for a couple of times; I finally got to finish the patch and submit.