### PR TITLE
Improve the error handling in the gather and import stage

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -14,6 +14,14 @@ if [ $CKANVERSION != 'master' ]
 then
     git checkout release-v$CKANVERSION-latest
 fi
+
+# install the recommended version of setuptools
+if [ -f requirement-setuptools.txt ]
+then
+    echo "Updating setuptools..."
+    pip install -r requirement-setuptools.txt
+fi
+
 python setup.py develop
 
 

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -205,9 +205,8 @@ class DCATRDFHarvester(DCATHarvester):
                 self._save_gather_error('Error parsing the RDF file: {0}'.format(e), harvest_job)
                 return []
 
-            while True:
-                try:
-                    dataset = next(parser.datasets())
+            try:
+                for dataset in parser.datasets():
                     if not dataset.get('name'):
                         dataset['name'] = self._gen_new_name(dataset['title'])
 
@@ -234,12 +233,10 @@ class DCATRDFHarvester(DCATHarvester):
 
                     obj.save()
                     object_ids.append(obj.id)
-                except StopIteration:
-                    break;
-                except RDFParserException, e:
-                    self._save_gather_error('Error when processsing dataset: %r / %s' % (e, traceback.format_exc()),
-                                            harvest_job)
-                    return []
+            except Exception, e:
+                self._save_gather_error('Error when processsing dataset: %r / %s' % (e, traceback.format_exc()),
+                                        harvest_job)
+                return []
 
             # get the next page
             next_page_url = parser.next_page()

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -170,20 +170,14 @@ class RDFParser(RDFProcessor):
         Each dataset is passed to all the loaded profiles before being
         yielded, so it can be further modified by each one of them.
 
-        It raises a ``RDFParserException`` if there was some error during
-        the parsing.
-
         Returns a dataset dict that can be passed to eg `package_create`
         or `package_update`
         '''
         for dataset_ref in self._datasets():
             dataset_dict = {}
             for profile_class in self._profiles:
-                try:
-                    profile = profile_class(self.g, self.compatibility_mode)
-                    profile.parse_dataset(dataset_dict, dataset_ref)
-                except Exception, e:
-                    raise RDFParserException(e)
+                profile = profile_class(self.g, self.compatibility_mode)
+                profile.parse_dataset(dataset_dict, dataset_ref)
 
             yield dataset_dict
 

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -170,14 +170,20 @@ class RDFParser(RDFProcessor):
         Each dataset is passed to all the loaded profiles before being
         yielded, so it can be further modified by each one of them.
 
+        It raises a ``RDFParserException`` if there was some error during
+        the parsing.
+
         Returns a dataset dict that can be passed to eg `package_create`
         or `package_update`
         '''
         for dataset_ref in self._datasets():
             dataset_dict = {}
             for profile_class in self._profiles:
-                profile = profile_class(self.g, self.compatibility_mode)
-                profile.parse_dataset(dataset_dict, dataset_ref)
+                try:
+                    profile = profile_class(self.g, self.compatibility_mode)
+                    profile.parse_dataset(dataset_dict, dataset_ref)
+                except Exception, e:
+                    raise RDFParserException(e)
 
             yield dataset_dict
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -17,6 +17,7 @@ from ckanext.harvest import queue
 
 from ckanext.dcat.harvesters import DCATRDFHarvester
 from ckanext.dcat.interfaces import IDCATRDFHarvester
+import ckanext.dcat.harvesters.rdf
 
 
 eq_ = nose.tools.eq_
@@ -98,6 +99,18 @@ class TestRDFNullHarvester(TestRDFHarvester):
     def before_create(self, harvest_object, dataset_dict, temp_dict):
         super(TestRDFNullHarvester, self).before_create(harvest_object, dataset_dict, temp_dict)
         dataset_dict.clear()
+
+
+class TestRDFExceptionHarvester(TestRDFHarvester):
+    p.implements(IDCATRDFHarvester)
+
+    raised_exception = False
+
+    def before_create(self, harvest_object, dataset_dict, temp_dict):
+        super(TestRDFExceptionHarvester, self).before_create(harvest_object, dataset_dict, temp_dict)
+        if not self.raised_exception:
+            self.raised_exception = True
+            raise Exception("raising exception in before_create")
 
 
 class TestDCATHarvestUnit(object):
@@ -779,7 +792,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         assert ('Error parsing the RDF file'
                 in last_job_status['gather_error_summary'][0][0])
 
-    @patch.object('ckanext.dcat.harvesters.rdf.RDFParser', 'datasets')
+    @patch.object(ckanext.dcat.harvesters.rdf.RDFParser, 'datasets')
     def test_harvest_exception_in_profile(self, mock_datasets):
         mock_datasets.side_effect = Exception
 
@@ -790,7 +803,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         # The harvester will try to do a HEAD request first so we need to mock
         # this as well
         httpretty.register_uri(httpretty.HEAD, self.rdf_mock_url,
-                               status=405, content_type=selt.rdf_content_type)
+                               status=405, content_type=self.rdf_content_type)
 
         harvest_source = self._create_harvest_source(self.rdf_mock_url)
         self._create_harvest_job(harvest_source['id'])
@@ -1091,6 +1104,18 @@ class TestDCATHarvestFunctionalSetNull(FunctionalHarvestTest):
     def teardown_class(self):
         p.unload('test_rdf_null_harvester')
 
+    def setup(self):
+        super(TestDCATHarvestFunctionalSetNull, self).setup()
+
+        plugin = p.get_plugin('test_rdf_null_harvester')
+        plugin.calls = defaultdict(int)
+
+    def teardown(self):
+        super(TestDCATHarvestFunctionalSetNull, self).teardown()
+
+        plugin = p.get_plugin('test_rdf_null_harvester')
+        plugin.calls = defaultdict(int)
+
     def test_harvest_with_before_create_null(self):
         plugin = p.get_plugin('test_rdf_null_harvester')
 
@@ -1133,6 +1158,78 @@ class TestDCATHarvestFunctionalSetNull(FunctionalHarvestTest):
 
         eq_(plugin.calls['before_create'], 2)
         eq_(plugin.calls['after_create'], 0)
+        eq_(plugin.calls['before_update'], 0)
+        eq_(plugin.calls['after_update'], 0)
+
+
+class TestDCATHarvestFunctionalRaiseExcpetion(FunctionalHarvestTest):
+
+    @classmethod
+    def setup_class(self):
+        super(TestDCATHarvestFunctionalRaiseExcpetion, self).setup_class()
+        p.load('test_rdf_exception_harvester')
+
+    @classmethod
+    def teardown_class(self):
+        p.unload('test_rdf_exception_harvester')
+
+    def setup(self):
+        super(TestDCATHarvestFunctionalRaiseExcpetion, self).setup()
+
+        plugin = p.get_plugin('test_rdf_exception_harvester')
+        plugin.calls = defaultdict(int)
+
+    def teardown(self):
+        super(TestDCATHarvestFunctionalRaiseExcpetion, self).teardown()
+
+        plugin = p.get_plugin('test_rdf_exception_harvester')
+        plugin.calls = defaultdict(int)
+
+    def test_harvest_with_before_create_raising_exception(self):
+        plugin = p.get_plugin('test_rdf_exception_harvester')
+
+        url = self.rdf_mock_url
+        content =  self.rdf_content
+        content_type = self.rdf_content_type
+
+        # Mock the GET request to get the file
+        httpretty.register_uri(httpretty.GET, url,
+                               body=content, content_type=content_type)
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well
+        httpretty.register_uri(httpretty.HEAD, url,
+                               status=405, content_type=content_type)
+
+        harvest_source = self._create_harvest_source(url)
+
+        self._run_full_job(harvest_source['id'], num_objects=2)
+
+        # Run the jobs to mark the previous one as Finished
+        self._run_jobs()
+
+        # Get the harvest source with the updated status
+        harvest_source = h.call_action('harvest_source_show',
+                                       id=harvest_source['id'])
+        last_job_status = harvest_source['status']['last_job']
+        eq_(last_job_status['status'], 'Finished')
+
+        assert ('Error importing dataset'
+                in last_job_status['object_error_summary'][0][0])
+
+        nose.tools.assert_dict_equal(
+            last_job_status['stats'],
+            {
+                'deleted': 0,
+                'added': 1,
+                'updated': 0,
+                'not modified': 0,
+                'errored': 1
+            }
+        )
+
+        eq_(plugin.calls['before_create'], 2)
+        eq_(plugin.calls['after_create'], 1)
         eq_(plugin.calls['before_update'], 0)
         eq_(plugin.calls['after_update'], 0)
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     # Test plugins
     test_rdf_harvester=ckanext.dcat.tests.test_harvester:TestRDFHarvester
     test_rdf_null_harvester=ckanext.dcat.tests.test_harvester:TestRDFNullHarvester
+    test_rdf_exception_harvester=ckanext.dcat.tests.test_harvester:TestRDFExceptionHarvester
 
     [ckan.rdf.profiles]
     euro_dcat_ap=ckanext.dcat.profiles:EuropeanDCATAPProfile


### PR DESCRIPTION
- Raise exceptions when `parse_dataset` in profiles fails
- Do not update content hash if download errored
- Call `_save_gather_error` if `datasets()` generators fails