### PR TITLE
[#75] Schema.org mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,15 @@ To disable this behavior, you can set the following config value in your ini fil
 To add [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) to dataset pages, activate the `structured_data` plugin in your ini file.
 
 By default this uses the `schemaorg` profile (see [profiles](#profiles)) to serialize the dataset to JSON-LD, which is then added to the dataset detail page.
-Example:
+To change the schema, you have to override the Jinja template block called `structured_data` in [`templates/package/read_base.html`](https://github.com/ckan/ckanext-dcat/blob/master/ckanext/dcat/templates/package/read_base.html) and call the template helper function with different parameters:
+
+    {% block structured_data %}
+      <script type="application/ld+json">
+      {{ h.structured_data(pkg.id, ['my_custom_schema'])|safe }}
+      </script>
+    {% endblock %}
+
+Example output of structured data in JSON-LD:
 
     < ... >
         <script type="application/ld+json">

--- a/README.md
+++ b/README.md
@@ -801,7 +801,9 @@ To disable this behavior, you can set the following config value in your ini fil
 
 ## Structured data
 
-To add [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) to dataset pages, activate the `structured_data` plugin in your ini file.
+To add [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) to dataset pages, activate the `structured_data` and `dcat` plugins in your ini file:
+
+        ckan.plugins = dcat structured_data
 
 By default this uses the `schemaorg` profile (see [profiles](#profiles)) to serialize the dataset to JSON-LD, which is then added to the dataset detail page.
 To change the schema, you have to override the Jinja template block called `structured_data` in [`templates/package/read_base.html`](https://github.com/ckan/ckanext-dcat/blob/master/ckanext/dcat/templates/package/read_base.html) and call the template helper function with different parameters:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ These are implemented internally using:
 
 ## RDF DCAT endpoints
 
-When the `dcat` plugin is enabled, the following RDF endpoints are available on your CKAN instance. The schema used on the serializations can be customized using [profiles](#profiles).
+By default when the `dcat` plugin is enabled, the following RDF endpoints are available on your CKAN instance. The schema used on the serializations can be customized using [profiles](#profiles).
+
+To disable the RDF endpoints, you can set the following config in your ini file:
+
+    ckanext.dcat.enable_rdf_endpoints = False
+
 
 ### Dataset endpoints
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This extension provides plugins that allow CKAN to expose and consume metadata f
     - [Compatibility mode](#compatibility-mode)
 - [XML DCAT harvester (deprecated)](#xml-dcat-harvester-deprecated)
 - [Translation of fields](#translation-of-fields)
-- [Structured Data](#strucuted-data)
+- [Structured Data](#structured-data)
 - [Running the Tests](#running-the-tests)
 - [Acknowledgements](#acknowledgements)
 - [Copying and License](#copying-and-license)

--- a/ckanext/dcat/controllers.py
+++ b/ckanext/dcat/controllers.py
@@ -32,10 +32,15 @@ class DCATController(BaseController):
         if not _format:
             return HomeController().index()
 
+        _profiles = toolkit.request.params.get('profiles')
+        if _profiles:
+            _profiles = _profiles.split(',')
+
         data_dict = {
             'page': toolkit.request.params.get('page'),
             'modified_since': toolkit.request.params.get('modified_since'),
             'format': _format,
+            'profiles': _profiles,
         }
 
         toolkit.response.headers.update(
@@ -52,13 +57,17 @@ class DCATController(BaseController):
 
         if not _format:
             return PackageController().read(_id)
+        
+        _profiles = toolkit.request.params.get('profiles')
+        if _profiles:
+            _profiles = _profiles.split(',')
 
         toolkit.response.headers.update(
             {'Content-type': CONTENT_TYPES[_format]})
 
         try:
             result = toolkit.get_action('dcat_dataset_show')({}, {'id': _id,
-                'format': _format})
+                'format': _format, 'profiles': _profiles})
         except toolkit.ObjectNotFound:
             toolkit.abort(404)
 

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -23,7 +23,7 @@ def dcat_dataset_show(context, data_dict):
 
     dataset_dict = toolkit.get_action('package_show')(context, data_dict)
 
-    serializer = RDFSerializer()
+    serializer = RDFSerializer(profiles=data_dict.get('profiles'))
 
     output = serializer.serialize_dataset(dataset_dict,
                                           _format=data_dict.get('format'))
@@ -40,7 +40,7 @@ def dcat_catalog_show(context, data_dict):
     dataset_dicts = query['results']
     pagination_info = _pagination_info(query, data_dict)
 
-    serializer = RDFSerializer()
+    serializer = RDFSerializer(profiles=data_dict.get('profiles'))
 
     output = serializer.serialize_catalog({}, dataset_dicts,
                                           _format=data_dict.get('format'),
@@ -59,7 +59,7 @@ def dcat_catalog_search(context, data_dict):
     dataset_dicts = query['results']
     pagination_info = _pagination_info(query, data_dict)
 
-    serializer = RDFSerializer()
+    serializer = RDFSerializer(profiles=data_dict.get('profiles'))
 
     output = serializer.serialize_catalog({}, dataset_dicts,
                                           _format=data_dict.get('format'),

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -148,8 +148,11 @@ class DCATJSONInterface(p.SingletonPlugin):
         }
 
 
-class SchemaOrgPlugin(p.SingletonPlugin):
-    # TODO: add template helper to output JSON-LD in read.html
-    # TODO: allow loading of values from a specific profile
-    pass
+class StructuredDataPlugin(p.SingletonPlugin):
+    p.implements(p.ITemplateHelpers, inherit=True)
+
+    def get_helpers(self):
+        return {
+            'structured_data': utils.structured_data,
+        }
 

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -146,3 +146,9 @@ class DCATJSONInterface(p.SingletonPlugin):
         return {
             'dcat_datasets_list': dcat_auth,
         }
+
+
+class SchemaOrgPlugin(p.SinlgetonPlugin):
+    # TODO: add template helper to output JSON-LD in read.html
+    pass
+

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -18,6 +18,7 @@ from ckanext.dcat import utils
 
 DEFAULT_CATALOG_ENDPOINT = '/catalog.{_format}'
 CUSTOM_ENDPOINT_CONFIG = 'ckanext.dcat.catalog_endpoint'
+ENABLE_RDF_ENDPOINTS_CONFIG = 'ckanext.dcat.enable_rdf_endpoints'
 ENABLE_CONTENT_NEGOTIATION_CONFIG = 'ckanext.dcat.enable_content_negotiation'
 TRANSLATE_KEYS_CONFIG = 'ckanext.dcat.translate_keys'
 
@@ -63,15 +64,17 @@ class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
 
         controller = 'ckanext.dcat.controllers:DCATController'
 
-        _map.connect('dcat_catalog',
-                     config.get('ckanext.dcat.catalog_endpoint',
-                                DEFAULT_CATALOG_ENDPOINT),
-                     controller=controller, action='read_catalog',
-                     requirements={'_format': 'xml|rdf|n3|ttl|jsonld'})
+        if p.toolkit.asbool(config.get(ENABLE_RDF_ENDPOINTS_CONFIG, True)):
 
-        _map.connect('dcat_dataset', '/dataset/{_id}.{_format}',
-                     controller=controller, action='read_dataset',
-                     requirements={'_format': 'xml|rdf|n3|ttl|jsonld'})
+            _map.connect('dcat_catalog',
+                         config.get('ckanext.dcat.catalog_endpoint',
+                                    DEFAULT_CATALOG_ENDPOINT),
+                         controller=controller, action='read_catalog',
+                         requirements={'_format': 'xml|rdf|n3|ttl|jsonld'})
+
+            _map.connect('dcat_dataset', '/dataset/{_id}.{_format}',
+                         controller=controller, action='read_dataset',
+                         requirements={'_format': 'xml|rdf|n3|ttl|jsonld'})
 
         if p.toolkit.asbool(config.get(ENABLE_CONTENT_NEGOTIATION_CONFIG)):
 

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -148,7 +148,8 @@ class DCATJSONInterface(p.SingletonPlugin):
         }
 
 
-class SchemaOrgPlugin(p.SinlgetonPlugin):
+class SchemaOrgPlugin(p.SingletonPlugin):
     # TODO: add template helper to output JSON-LD in read.html
+    # TODO: allow loading of values from a specific profile
     pass
 

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -25,6 +25,7 @@ TRANSLATE_KEYS_CONFIG = 'ckanext.dcat.translate_keys'
 class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
 
     p.implements(p.IConfigurer, inherit=True)
+    p.implements(p.ITemplateHelpers, inherit=True)
     p.implements(p.IRoutes, inherit=True)
     p.implements(p.IActions, inherit=True)
     p.implements(p.IAuthFunctions, inherit=True)
@@ -50,6 +51,12 @@ class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
                 raise Exception(
                     '"{0}" should contain {{_format}}'.format(
                         CUSTOM_ENDPOINT_CONFIG))
+
+    # ITemplateHelpers
+    def get_helpers(self):
+        return {
+            'helper_available': utils.helper_available,
+        }
 
     # IRoutes
     def before_map(self, _map):
@@ -151,6 +158,7 @@ class DCATJSONInterface(p.SingletonPlugin):
 class StructuredDataPlugin(p.SingletonPlugin):
     p.implements(p.ITemplateHelpers, inherit=True)
 
+    # ITemplateHelpers
     def get_helpers(self):
         return {
             'structured_data': utils.structured_data,

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -3,7 +3,7 @@ import json
 
 from dateutil.parser import parse as parse_date
 
-from pylons import config
+from ckantoolkit import config
 
 import rdflib
 from rdflib import URIRef, BNode, Literal

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1212,8 +1212,7 @@ class SchemaOrgProfile(RDFProfile):
             default_datetime = datetime.datetime(1, 1, 1, 0, 0, 0)
             _date = parse_date(value, default=default_datetime)
 
-            self.g.add((subject, predicate, _type(_date.isoformat(),
-                                                  datatype=SCHEMA.DateTime)))
+            self.g.add((subject, predicate, _type(_date.isoformat())))
         except ValueError:
             self.g.add((subject, predicate, _type(value)))
 

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1033,6 +1033,7 @@ class EuropeanDCATAPProfile(RDFProfile):
                 g.add((spatial_ref,
                        LOCN.geometry,
                        Literal(spatial_geom, datatype=GEOJSON_IMT)))
+                # WKT, because GeoDCAT-AP says so
                 try:
                     g.add((spatial_ref,
                            LOCN.geometry,

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -17,7 +17,7 @@
     https://developers.google.com/search/docs/guides/intro-structured-data
     #}
 
-    {% if h.get('structured_data') %}
+    {% if h.helper_available('structured_data') %}
     <script type="application/ld+json">
     {{ h.structured_data(pkg.id)|safe }}
     </script>

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -17,7 +17,7 @@
     https://developers.google.com/search/docs/guides/intro-structured-data
     #}
 
-    {% if h.structured_data %}
+    {% if structured_data in h %}
     <script type="application/ld+json">
     {{ h.structured_data(pkg.id) }}
     </script>

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -6,3 +6,21 @@
    <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for('dcat_dataset', _id=pkg.id, _format='xml', qualified=True) }}"/>
    <link rel="alternate" type="application/ld+json" href="{{ h.url_for('dcat_dataset', _id=pkg.id, _format='jsonld', qualified=True) }}"/>
 {% endblock -%}
+{% block body_extras %}
+  {{ super() }}
+  {% block structured_data %}
+    {#
+    h.structured_data is defined in the 'structured_data' plugin,
+    you have to activate the plugin (or implement the method yourself)
+    to make use of this feature.
+    More information about structured data:
+    https://developers.google.com/search/docs/guides/intro-structured-data
+    #}
+
+    {% if h.structured_data %}
+    <script type="application/ld+json">
+    {{ h.structured_data(pkg.id) }}
+    </script>
+    {% endif %}
+  {% endblock %}
+{% endblock %}

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -17,9 +17,9 @@
     https://developers.google.com/search/docs/guides/intro-structured-data
     #}
 
-    {% if structured_data in h %}
+    {% if h.get('structured_data') %}
     <script type="application/ld+json">
-    {{ h.structured_data(pkg.id) }}
+    {{ h.structured_data(pkg.id)|safe }}
     </script>
     {% endif %}
   {% endblock %}

--- a/ckanext/dcat/tests/test_base_parser.py
+++ b/ckanext/dcat/tests/test_base_parser.py
@@ -1,6 +1,6 @@
 import nose
 
-from pylons import config
+from ckantoolkit import config
 
 from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import Namespace, RDF

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -6,14 +6,11 @@ import nose
 from ckan import plugins as p
 from ckan.lib.helpers import url_for
 
-from pylons import config
+from ckantoolkit import config
 
 from rdflib import Graph
 
-try:
-    from ckan.tests import helpers, factories
-except ImportError:
-    from ckan.new_tests import helpers, factories
+from ckantoolkit.tests import helpers, factories
 
 from ckanext.dcat.processors import RDFParser
 from ckanext.dcat.profiles import RDF, DCAT

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -529,14 +529,14 @@ class TestStructuredData(helpers.FunctionalTestBase):
 
     @classmethod
     def teardown_class(cls):
-        super(TestTranslations, cls).teardown_class()
+        super(TestStructuredData, cls).teardown_class()
         helpers.reset_db()
 
     def test_structured_data_generated(self):
 
-        dataset = factories.Dataset(extras=[
-            {'key': 'notes', 'value': 'bla'}
-        ])
+        dataset = factories.Dataset(
+            notes='test description'
+        )
 
         url = url_for('dataset_read', id=dataset['id'])
 
@@ -545,15 +545,15 @@ class TestStructuredData(helpers.FunctionalTestBase):
         response = app.get(url)
 
         assert '<script type="application/ld+json">' in response.body
-        assert '"schema:description": "bla"' in response.body
+        assert '"schema:description": "test description"' in response.body
 
 
-    def test_labels_translated(self):
+    def test_structured_data_not_generated(self):
         p.unload('structured_data')
 
-        dataset = factories.Dataset(extras=[
-            {'key': 'notes', 'value': 'bla'}
-        ])
+        dataset = factories.Dataset(
+            notes='test description'
+        )
 
         url = url_for('dataset_read', id=dataset['id'])
 

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -198,7 +198,6 @@ class TestEndpoints(helpers.FunctionalTestBase):
 
         content = response.body
 
-        assert '"@id": "/dataset/%s"' % dataset['id'] in content
         assert '"@type": "schema:Dataset"' in content
         assert '"schema:description": "%s"' % dataset['notes'] in content
 

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -23,12 +23,12 @@ assert_true = nose.tools.assert_true
 class TestEndpoints(helpers.FunctionalTestBase):
 
     def setup(self):
+        super(TestEndpoints, self).setup()
         if not p.plugin_loaded('dcat'):
             p.load('dcat')
 
     def teardown(self):
         p.unload('dcat')
-        helpers.reset_db()
 
     def _object_value(self, graph, subject, predicate):
 

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -523,3 +523,41 @@ class TestTranslations(helpers.FunctionalTestBase):
         assert not 'Notes de la versió' in response.body
         assert not 'Version notes' in response.body
         assert 'version_notes' in response.body
+
+
+class TestStructuredData(helpers.FunctionalTestBase):
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestTranslations, cls).teardown_class()
+        helpers.reset_db()
+
+    def test_structured_data_generated(self):
+
+        dataset = factories.Dataset(extras=[
+            {'key': 'notes', 'value': 'bla'}
+        ])
+
+        url = url_for('dataset_read', id=dataset['id'])
+
+        app = self._get_test_app()
+
+        response = app.get(url)
+
+        assert '<script type="application/ld+json">' in response.body
+        assert '"schema:description": "bla"' in response.body
+
+
+    def test_labels_translated(self):
+        p.unload('structured_data')
+
+        dataset = factories.Dataset(extras=[
+            {'key': 'notes', 'value': 'bla'}
+        ])
+
+        url = url_for('dataset_read', id=dataset['id'])
+
+        app = self._get_test_app()
+
+        response = app.get(url)
+        assert not '<script type="application/ld+json">' in response.body

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -208,6 +208,16 @@ class TestEndpoints(helpers.FunctionalTestBase):
         app = self._get_test_app()
         app.get(url, status=404)
 
+    @helpers.change_config('ckanext.dcat.enable_rdf_endpoints', False)
+    def test_dataset_endpoint_disabled(self):
+        dataset = factories.Dataset(
+            notes='Test dataset'
+        )
+        url = url_for('dcat_dataset', _id=dataset['id'], _format='xml')
+
+        app = self._get_test_app()
+        app.get(url, status=404)
+
     def test_dataset_form_is_rendered(self):
         sysadmin = factories.Sysadmin()
         env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
@@ -338,6 +348,13 @@ class TestEndpoints(helpers.FunctionalTestBase):
 
         eq_(self._object_value(g, pagination, HYDRA.lastPage),
             url_for('dcat_catalog', _format='rdf', page=2, host='test.ckan.net'))
+
+    @helpers.change_config('ckanext.dcat.enable_rdf_endpoints', False)
+    def test_catalog_endpoint_disabled(self):
+        url = url_for('dcat_catalog', _format='rdf')
+
+        app = self._get_test_app()
+        app.get(url, status=404)
 
 
 class TestAcceptHeader(helpers.FunctionalTestBase):

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -27,6 +27,13 @@ class TestEndpoints(helpers.FunctionalTestBase):
         super(TestEndpoints, cls).teardown_class()
         helpers.reset_db()
 
+    def setup(self):
+        if not p.plugin_loaded('dcat'):
+            p.load('dcat')
+
+    def teardown(self):
+        p.unload('dcat')
+
     def _object_value(self, graph, subject, predicate):
 
         objects = [o for o in graph.objects(subject, predicate)]

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -182,6 +182,26 @@ class TestEndpoints(helpers.FunctionalTestBase):
         eq_(dcat_dataset['title'], dataset['title'])
         eq_(dcat_dataset['notes'], dataset['notes'])
 
+    def test_dataset_profiles_jsonld(self):
+
+        dataset = factories.Dataset(
+            notes='Test dataset'
+        )
+
+        url = url_for('dcat_dataset', _id=dataset['id'], _format='jsonld', profiles='schemaorg')
+
+        app = self._get_test_app()
+
+        response = app.get(url)
+
+        eq_(response.headers['Content-Type'], 'application/ld+json')
+
+        content = response.body
+
+        assert '"@id": "/dataset/%s"' % dataset['id'] in content
+        assert '"@type": "schema:Dataset"' in content
+        assert '"schema:description": "%s"' % dataset['notes'] in content
+
     def test_dataset_not_found(self):
         import uuid
 

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -210,10 +210,13 @@ class TestEndpoints(helpers.FunctionalTestBase):
 
     @helpers.change_config('ckanext.dcat.enable_rdf_endpoints', False)
     def test_dataset_endpoint_disabled(self):
+        p.unload('dcat')
+        p.load('dcat')
         dataset = factories.Dataset(
             notes='Test dataset'
         )
         url = url_for('dcat_dataset', _id=dataset['id'], _format='xml')
+        print url
 
         app = self._get_test_app()
         app.get(url, status=404)
@@ -351,7 +354,10 @@ class TestEndpoints(helpers.FunctionalTestBase):
 
     @helpers.change_config('ckanext.dcat.enable_rdf_endpoints', False)
     def test_catalog_endpoint_disabled(self):
+        p.unload('dcat')
+        p.load('dcat')
         url = url_for('dcat_catalog', _format='rdf')
+        print url
 
         app = self._get_test_app()
         app.get(url, status=404)

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -22,17 +22,13 @@ assert_true = nose.tools.assert_true
 
 class TestEndpoints(helpers.FunctionalTestBase):
 
-    @classmethod
-    def teardown_class(cls):
-        super(TestEndpoints, cls).teardown_class()
-        helpers.reset_db()
-
     def setup(self):
         if not p.plugin_loaded('dcat'):
             p.load('dcat')
 
     def teardown(self):
         p.unload('dcat')
+        helpers.reset_db()
 
     def _object_value(self, graph, subject, predicate):
 
@@ -222,11 +218,10 @@ class TestEndpoints(helpers.FunctionalTestBase):
         dataset = factories.Dataset(
             notes='Test dataset'
         )
+        # without the route, url_for returns the given parameters
         url = url_for('dcat_dataset', _id=dataset['id'], _format='xml')
-        print url
-
-        app = self._get_test_app()
-        app.get(url, status=404)
+        assert not url.startswith('/')
+        assert url.startswith('dcat_dataset')
 
     def test_dataset_form_is_rendered(self):
         sysadmin = factories.Sysadmin()
@@ -363,11 +358,10 @@ class TestEndpoints(helpers.FunctionalTestBase):
     def test_catalog_endpoint_disabled(self):
         p.unload('dcat')
         p.load('dcat')
+        # without the route, url_for returns the given parameters
         url = url_for('dcat_catalog', _format='rdf')
-        print url
-
-        app = self._get_test_app()
-        app.get(url, status=404)
+        assert not url.startswith('/')
+        assert url.startswith('dcat_catalog')
 
 
 class TestAcceptHeader(helpers.FunctionalTestBase):

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -3,17 +3,15 @@ import json
 
 import nose
 
+from ckantoolkit import config
+
 from rdflib import Graph, URIRef, BNode, Literal
 from rdflib.namespace import RDF
 
 from ckan.plugins import toolkit
 
-try:
-    from ckan.tests import helpers
-except ImportError:
-    from ckan.new_tests import helpers
+from ckantoolkit.tests import helpers, factories
 
-from ckan import plugins
 from ckanext.dcat.processors import RDFParser, RDFSerializer
 from ckanext.dcat.profiles import (DCAT, DCT, ADMS, LOCN, SKOS, GSP, RDFS,
                                    GEOJSON_IMT)

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
@@ -2,7 +2,7 @@ import json
 
 import nose
 
-from pylons import config
+from ckantoolkit import config
 
 from dateutil.parser import parse as parse_date
 from rdflib import URIRef, BNode, Literal
@@ -10,10 +10,7 @@ from rdflib.namespace import RDF
 
 from geomet import wkt
 
-try:
-    from ckan.tests import helpers, factories
-except ImportError:
-    from ckan.new_tests import helpers, factories
+from ckantoolkit.tests import helpers, factories
 
 from ckanext.dcat import utils
 from ckanext.dcat.processors import RDFSerializer

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -7,10 +7,7 @@ import httpretty
 from mock import patch
 
 import ckan.plugins as p
-try:
-    import ckan.new_tests.helpers as h
-except ImportError:
-    import ckan.tests.helpers as h
+import ckantoolkit.tests.helpers as h
 
 import ckanext.harvest.model as harvest_model
 from ckanext.harvest import queue

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -1,14 +1,11 @@
 import nose
 import mock
 
-from pylons import config
+from ckantoolkit import config
 
 from ckan.plugins import toolkit
 
-try:
-    from ckan.tests import helpers
-except ImportError:
-    from ckan.new_tests import helpers
+from ckantoolkit.tests import helpers
 
 from ckanext.dcat.logic import _pagination_info
 

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -1,0 +1,545 @@
+import json
+
+import nose
+
+from ckantoolkit import config
+
+from dateutil.parser import parse as parse_date
+from rdflib import URIRef, BNode, Literal
+from rdflib.namespace import RDF
+
+from ckantoolkit.tests import helpers, factories
+
+from ckanext.dcat import utils
+from ckanext.dcat.processors import RDFSerializer
+from ckanext.dcat.profiles import SCHEMA
+
+from ckanext.dcat.tests.test_euro_dcatap_profile_serialize import BaseSerializeTest
+
+eq_ = nose.tools.eq_
+assert_true = nose.tools.assert_true
+
+
+class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
+
+    def test_graph_from_dataset(self):
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'notes': 'Lorem ipsum',
+            'url': 'http://example.com/ds1',
+            'version': '1.0b',
+            'metadata_created': '2015-06-26T15:21:09.034694',
+            'metadata_modified': '2015-06-26T15:21:09.075774',
+            'tags': [{'name': 'Tag 1'}, {'name': 'Tag 2'}],
+            'extras': [
+                {'key': 'alternate_identifier', 'value': '[\"xyz\", \"abc\"]'},
+                {'key': 'identifier', 'value': '26be5452-fc5c-11e7-8450-fea9aa178066'},
+                {'key': 'version_notes', 'value': 'This is a beta version'},
+                {'key': 'frequency', 'value': 'monthly'},
+                {'key': 'language', 'value': '[\"en\"]'},
+                {'key': 'theme', 'value': '[\"http://eurovoc.europa.eu/100142\", \"http://eurovoc.europa.eu/100152\"]'},
+                {'key': 'conforms_to', 'value': '[\"Standard 1\", \"Standard 2\"]'},
+                {'key': 'access_rights', 'value': 'public'},
+                {'key': 'documentation', 'value': '[\"http://dataset.info.org/doc1\", \"http://dataset.info.org/doc2\"]'},
+                {'key': 'provenance', 'value': 'Some statement about provenance'},
+                {'key': 'dcat_type', 'value': 'test-type'},
+                {'key': 'related_resource', 'value': '[\"http://dataset.info.org/related1\", \"http://dataset.info.org/related2\"]'},
+                {'key': 'has_version', 'value': '[\"https://data.some.org/catalog/datasets/derived-dataset-1\", \"https://data.some.org/catalog/datasets/derived-dataset-2\"]'},
+                {'key': 'is_version_of', 'value': '[\"https://data.some.org/catalog/datasets/original-dataset\"]'},
+                {'key': 'source', 'value': '[\"https://data.some.org/catalog/datasets/source-dataset-1\", \"https://data.some.org/catalog/datasets/source-dataset-2\"]'},
+                {'key': 'sample', 'value': '[\"https://data.some.org/catalog/datasets/9df8df51-63db-37a8-e044-0003ba9b0d98/sample\"]'},
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        eq_(unicode(dataset_ref), utils.dataset_uri(dataset))
+
+        # Basic fields
+        assert self._triple(g, dataset_ref, RDF.type, SCHEMA.Dataset)
+        assert self._triple(g, dataset_ref, SCHEMA.name, dataset['title'])
+        assert self._triple(g, dataset_ref, SCHEMA.description, dataset['notes'])
+        assert self._triple(g, dataset_ref, SCHEMA.version, dataset['version'])
+        assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'])
+        assert self._triple(g, dataset_ref, SCHEMA.dateModified, dataset['metadata_modified'])
+
+        # Tags
+        eq_(len([t for t in g.triples((dataset_ref, SCHEMA.keywords, None))]), 2)
+        for tag in dataset['tags']:
+            assert self._triple(g, dataset_ref, SCHEMA.keywords, tag['name'])
+
+        # List
+        for item in [
+            ('language', SCHEMA.inLanguage, Literal),
+            ('theme', SCHEMA.about, URIRef),
+        ]:
+            values = json.loads(extras[item[0]])
+            eq_(len([t for t in g.triples((dataset_ref, item[1], None))]), len(values))
+            for value in values:
+                assert self._triple(g, dataset_ref, item[1], item[2](value))
+
+    # def test_contact_details_extras(self):
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'maintainer': 'Example Maintainer',
+    #         'maintainer_email': 'dep@example.com',
+    #         'author': 'Example Author',
+    #         'author_email': 'ped@example.com',
+    #         'extras': [
+    #             {'key': 'contact_uri', 'value': 'http://example.com/contact'},
+    #             {'key': 'contact_name', 'value': 'Example Contact'},
+    #             {'key': 'contact_email', 'value': 'contact@example.com'},
+
+    #         ]
+
+
+    #     }
+    #     extras = self._extras(dataset)
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     # Contact details
+
+    #     contact_details = self._triple(g, dataset_ref, DCAT.contactPoint, None)[2]
+    #     assert contact_details
+    #     eq_(unicode(contact_details), extras['contact_uri'])
+    #     assert self._triple(g, contact_details, VCARD.fn, extras['contact_name'])
+    #     assert self._triple(g, contact_details, VCARD.hasEmail, extras['contact_email'])
+
+    # def test_publisher_extras(self):
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'organization': {
+    #             'id': '',
+    #             'name': 'publisher1',
+    #             'title': 'Example Publisher from Org',
+    #         },
+    #         'extras': [
+    #             {'key': 'publisher_uri', 'value': 'http://example.com/publisher'},
+    #             {'key': 'publisher_name', 'value': 'Example Publisher'},
+    #             {'key': 'publisher_email', 'value': 'publisher@example.com'},
+    #             {'key': 'publisher_url', 'value': 'http://example.com/publisher/home'},
+    #             {'key': 'publisher_type', 'value': 'http://purl.org/adms/publishertype/Company'},
+    #         ]
+
+
+    #     }
+    #     extras = self._extras(dataset)
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     publisher = self._triple(g, dataset_ref, DCT.publisher, None)[2]
+    #     assert publisher
+    #     eq_(unicode(publisher), extras['publisher_uri'])
+
+    #     assert self._triple(g, publisher, RDF.type, FOAF.Organization)
+    #     assert self._triple(g, publisher, FOAF.name, extras['publisher_name'])
+    #     assert self._triple(g, publisher, FOAF.mbox, extras['publisher_email'])
+    #     assert self._triple(g, publisher, FOAF.homepage, URIRef(extras['publisher_url']))
+    #     assert self._triple(g, publisher, DCT.type, extras['publisher_type'])
+
+    # def test_publisher_org(self):
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'organization': {
+    #             'id': '',
+    #             'name': 'publisher1',
+    #             'title': 'Example Publisher from Org',
+    #         }
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     publisher = self._triple(g, dataset_ref, DCT.publisher, None)[2]
+    #     assert publisher
+
+    #     assert self._triple(g, publisher, RDF.type, FOAF.Organization)
+    #     assert self._triple(g, publisher, FOAF.name, dataset['organization']['title'])
+
+    # def test_temporal(self):
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'extras': [
+    #             {'key': 'temporal_start', 'value': '2015-06-26T15:21:09.075774'},
+    #             {'key': 'temporal_end', 'value': '2015-07-14'},
+    #         ]
+    #     }
+    #     extras = self._extras(dataset)
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     temporal = self._triple(g, dataset_ref, DCT.temporal, None)[2]
+    #     assert temporal
+
+    #     assert self._triple(g, temporal, RDF.type, DCT.PeriodOfTime)
+    #     assert self._triple(g, temporal, SCHEMA.startDate, parse_date(extras['temporal_start']).isoformat(), XSD.dateTime)
+    #     assert self._triple(g, temporal, SCHEMA.endDate, parse_date(extras['temporal_end']).isoformat(), XSD.dateTime)
+
+    # def test_spatial(self):
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'extras': [
+    #             {'key': 'spatial_uri', 'value': 'http://sws.geonames.org/6361390/'},
+    #             {'key': 'spatial_text', 'value': 'Tarragona'},
+    #             {'key': 'spatial', 'value': '{"type": "Polygon", "coordinates": [[[1.1870606,41.0786393],[1.1870606,41.1655218],[1.3752339,41.1655218],[1.3752339,41.0786393],[1.1870606,41.0786393]]]}'},
+
+    #         ]
+    #     }
+    #     extras = self._extras(dataset)
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     spatial = self._triple(g, dataset_ref, DCT.spatial, None)[2]
+    #     assert spatial
+    #     eq_(unicode(spatial), extras['spatial_uri'])
+    #     assert self._triple(g, spatial, RDF.type, DCT.Location)
+    #     assert self._triple(g, spatial, SKOS.prefLabel, extras['spatial_text'])
+
+    #     eq_(len([t for t in g.triples((spatial, LOCN.geometry, None))]), 2)
+    #     # Geometry in GeoJSON
+    #     assert self._triple(g, spatial, LOCN.geometry, extras['spatial'], GEOJSON_IMT)
+
+    #     # Geometry in WKT
+    #     wkt_geom = wkt.dumps(json.loads(extras['spatial']), decimals=4)
+    #     assert self._triple(g, spatial, LOCN.geometry, wkt_geom, GSP.wktLiteral)
+
+    # def test_spatial_bad_geojson_no_wkt(self):
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'extras': [
+    #             {'key': 'spatial', 'value': '{"key": "NotGeoJSON"}'},
+
+    #         ]
+    #     }
+    #     extras = self._extras(dataset)
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     spatial = self._triple(g, dataset_ref, DCT.spatial, None)[2]
+    #     assert spatial
+    #     assert_true(isinstance(spatial, BNode))
+    #     # Geometry in GeoJSON
+    #     assert self._triple(g, spatial, LOCN.geometry, extras['spatial'], GEOJSON_IMT)
+
+    #     # Geometry in WKT
+    #     eq_(len([t for t in g.triples((spatial, LOCN.geometry, None))]), 1)
+
+    # def test_distributions(self):
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             {
+    #                 'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #                 'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #                 'name': 'CSV file'
+    #             },
+    #             {
+    #                 'id': '8bceeda9-0084-477f-aa33-dad6148900d5',
+    #                 'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #                 'name': 'XLS file'
+    #             },
+    #             {
+    #                 'id': 'da73d939-0f11-45a1-9733-5de108383133',
+    #                 'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #                 'name': 'PDF file'
+    #             },
+
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     eq_(len([t for t in g.triples((dataset_ref, DCAT.distribution, None))]), 3)
+
+    #     for resource in dataset['resources']:
+    #         distribution = self._triple(g,
+    #                                     dataset_ref,
+    #                                     DCAT.distribution,
+    #                                     URIRef(utils.resource_uri(resource)))[2]
+
+    #         assert self._triple(g, distribution, RDF.type, DCAT.Distribution)
+    #         assert self._triple(g, distribution, DCT.title, resource['name'])
+
+    # def test_distribution_fields(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'description': 'A CSV file',
+    #         'url': 'http://example.com/data/file.csv',
+    #         'status': 'http://purl.org/adms/status/Completed',
+    #         'rights': 'Some statement about rights',
+    #         'license': 'http://creativecommons.org/licenses/by/3.0/',
+    #         'issued': '2015-06-26T15:21:09.034694',
+    #         'modified': '2015-06-26T15:21:09.075774',
+    #         'size': 1234,
+    #         'documentation': '[\"http://dataset.info.org/distribution1/doc1\", \"http://dataset.info.org/distribution1/doc2\"]',
+    #         'language': '[\"en\", \"es\", \"ca\"]',
+    #         'conforms_to': '[\"Standard 1\", \"Standard 2\"]',
+    #         'hash': '4304cf2e751e6053c90b1804c89c0ebb758f395a',
+    #         'hash_algorithm': 'http://spdx.org/rdf/terms#checksumAlgorithm_sha1',
+
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     eq_(len([t for t in g.triples((dataset_ref, DCAT.distribution, None))]), 1)
+
+    #     # URI
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+    #     eq_(unicode(distribution), utils.resource_uri(resource))
+
+    #     # Basic fields
+    #     assert self._triple(g, distribution, RDF.type, DCAT.Distribution)
+    #     assert self._triple(g, distribution, DCT.title, resource['name'])
+    #     assert self._triple(g, distribution, DCT.description, resource['description'])
+    #     assert self._triple(g, distribution, DCT.rights, resource['rights'])
+    #     assert self._triple(g, distribution, DCT.license, resource['license'])
+    #     assert self._triple(g, distribution, ADMS.status, resource['status'])
+
+    #     # List
+    #     for item in [
+    #         ('documentation', FOAF.page),
+    #         ('language', DCT.language),
+    #         ('conforms_to', DCT.conformsTo),
+    #     ]:
+    #         values = json.loads(resource[item[0]])
+    #         eq_(len([t for t in g.triples((distribution, item[1], None))]), len(values))
+    #         for value in values:
+    #             assert self._triple(g, distribution, item[1], value)
+
+    #     # Dates
+    #     assert self._triple(g, distribution, DCT.issued, resource['issued'], XSD.dateTime)
+    #     assert self._triple(g, distribution, DCT.modified, resource['modified'], XSD.dateTime)
+
+    #     # Numbers
+    #     assert self._triple(g, distribution, DCAT.byteSize, float(resource['size']), XSD.decimal)
+
+    #     # Checksum
+    #     checksum = self._triple(g, distribution, SPDX.checksum, None)[2]
+    #     assert checksum
+    #     assert self._triple(g, checksum, SPDX.checksumValue, resource['hash'], data_type='http://www.w3.org/2001/XMLSchema#hexBinary')
+    #     assert self._triple(g, checksum, SPDX.algorithm, URIRef(resource['hash_algorithm']))
+
+    # def test_distribution_access_url_only(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'url': 'http://example.com/data/file.csv',
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+    #     assert self._triple(g, distribution, DCAT.accessURL, URIRef(resource['url']))
+    #     assert self._triple(g, distribution, DCAT.downloadURL, None) is None
+
+    # def test_distribution_download_url_only(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'download_url': 'http://example.com/data/file.csv',
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+    #     assert self._triple(g, distribution, DCAT.downloadURL, URIRef(resource['download_url']))
+    #     assert self._triple(g, distribution, DCAT.accessURL, None) is None
+
+    # def test_distribution_both_urls_different(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'url': 'http://example.com/data/file',
+    #         'download_url': 'http://example.com/data/file.csv',
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+    #     assert self._triple(g, distribution, DCAT.accessURL, URIRef( resource['url']))
+    #     assert self._triple(g, distribution, DCAT.downloadURL, URIRef(resource['download_url']))
+
+    # def test_distribution_both_urls_the_same(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'url': 'http://example.com/data/file.csv',
+    #         'download_url': 'http://example.com/data/file.csv',
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+    #     assert self._triple(g, distribution, DCAT.downloadURL, URIRef(resource['url']))
+    #     assert self._triple(g, distribution, DCAT.accessURL, None) is None
+
+    # def test_distribution_format(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'url': 'http://example.com/data/file.csv',
+    #         'format': 'CSV',
+    #         'mimetype': 'text/csv',
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+    #     assert self._triple(g, distribution, DCT['format'], resource['format'])
+    #     assert self._triple(g, distribution, DCAT.mediaType, resource['mimetype'])
+
+    # def test_distribution_format_with_backslash(self):
+
+    #     resource = {
+    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
+    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'CSV file',
+    #         'url': 'http://example.com/data/file.csv',
+    #         'format': 'text/csv',
+    #     }
+
+    #     dataset = {
+    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+    #         'name': 'test-dataset',
+    #         'title': 'Test DCAT dataset',
+    #         'resources': [
+    #             resource
+    #         ]
+    #     }
+
+    #     s = RDFSerializer(profiles=['schemaorg'])
+    #     g = s.g
+
+    #     dataset_ref = s.graph_from_dataset(dataset)
+
+    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+    #     assert self._triple(g, distribution, DCAT.mediaType, resource['format'])
+

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -67,8 +67,11 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, SCHEMA.name, dataset['title'])
         assert self._triple(g, dataset_ref, SCHEMA.description, dataset['notes'])
         assert self._triple(g, dataset_ref, SCHEMA.version, dataset['version'])
-        assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'])
-        assert self._triple(g, dataset_ref, SCHEMA.dateModified, dataset['metadata_modified'])
+        assert self._triple(g, dataset_ref, SCHEMA.identifier, extras['identifier'])
+
+        # Dates
+        assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'], SCHEMA.DateTime)
+        assert self._triple(g, dataset_ref, SCHEMA.dateModified, dataset['metadata_modified'], SCHEMA.DateTime)
 
         # Tags
         eq_(len([t for t in g.triples((dataset_ref, SCHEMA.keywords, None))]), 2)
@@ -85,461 +88,399 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
             for value in values:
                 assert self._triple(g, dataset_ref, item[1], item[2](value))
 
-    # def test_contact_details_extras(self):
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'maintainer': 'Example Maintainer',
-    #         'maintainer_email': 'dep@example.com',
-    #         'author': 'Example Author',
-    #         'author_email': 'ped@example.com',
-    #         'extras': [
-    #             {'key': 'contact_uri', 'value': 'http://example.com/contact'},
-    #             {'key': 'contact_name', 'value': 'Example Contact'},
-    #             {'key': 'contact_email', 'value': 'contact@example.com'},
-
-    #         ]
-
-
-    #     }
-    #     extras = self._extras(dataset)
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     # Contact details
-
-    #     contact_details = self._triple(g, dataset_ref, DCAT.contactPoint, None)[2]
-    #     assert contact_details
-    #     eq_(unicode(contact_details), extras['contact_uri'])
-    #     assert self._triple(g, contact_details, VCARD.fn, extras['contact_name'])
-    #     assert self._triple(g, contact_details, VCARD.hasEmail, extras['contact_email'])
-
-    # def test_publisher_extras(self):
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'organization': {
-    #             'id': '',
-    #             'name': 'publisher1',
-    #             'title': 'Example Publisher from Org',
-    #         },
-    #         'extras': [
-    #             {'key': 'publisher_uri', 'value': 'http://example.com/publisher'},
-    #             {'key': 'publisher_name', 'value': 'Example Publisher'},
-    #             {'key': 'publisher_email', 'value': 'publisher@example.com'},
-    #             {'key': 'publisher_url', 'value': 'http://example.com/publisher/home'},
-    #             {'key': 'publisher_type', 'value': 'http://purl.org/adms/publishertype/Company'},
-    #         ]
-
-
-    #     }
-    #     extras = self._extras(dataset)
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     publisher = self._triple(g, dataset_ref, DCT.publisher, None)[2]
-    #     assert publisher
-    #     eq_(unicode(publisher), extras['publisher_uri'])
-
-    #     assert self._triple(g, publisher, RDF.type, FOAF.Organization)
-    #     assert self._triple(g, publisher, FOAF.name, extras['publisher_name'])
-    #     assert self._triple(g, publisher, FOAF.mbox, extras['publisher_email'])
-    #     assert self._triple(g, publisher, FOAF.homepage, URIRef(extras['publisher_url']))
-    #     assert self._triple(g, publisher, DCT.type, extras['publisher_type'])
-
-    # def test_publisher_org(self):
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'organization': {
-    #             'id': '',
-    #             'name': 'publisher1',
-    #             'title': 'Example Publisher from Org',
-    #         }
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     publisher = self._triple(g, dataset_ref, DCT.publisher, None)[2]
-    #     assert publisher
-
-    #     assert self._triple(g, publisher, RDF.type, FOAF.Organization)
-    #     assert self._triple(g, publisher, FOAF.name, dataset['organization']['title'])
-
-    # def test_temporal(self):
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'extras': [
-    #             {'key': 'temporal_start', 'value': '2015-06-26T15:21:09.075774'},
-    #             {'key': 'temporal_end', 'value': '2015-07-14'},
-    #         ]
-    #     }
-    #     extras = self._extras(dataset)
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     temporal = self._triple(g, dataset_ref, DCT.temporal, None)[2]
-    #     assert temporal
-
-    #     assert self._triple(g, temporal, RDF.type, DCT.PeriodOfTime)
-    #     assert self._triple(g, temporal, SCHEMA.startDate, parse_date(extras['temporal_start']).isoformat(), XSD.dateTime)
-    #     assert self._triple(g, temporal, SCHEMA.endDate, parse_date(extras['temporal_end']).isoformat(), XSD.dateTime)
-
-    # def test_spatial(self):
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'extras': [
-    #             {'key': 'spatial_uri', 'value': 'http://sws.geonames.org/6361390/'},
-    #             {'key': 'spatial_text', 'value': 'Tarragona'},
-    #             {'key': 'spatial', 'value': '{"type": "Polygon", "coordinates": [[[1.1870606,41.0786393],[1.1870606,41.1655218],[1.3752339,41.1655218],[1.3752339,41.0786393],[1.1870606,41.0786393]]]}'},
-
-    #         ]
-    #     }
-    #     extras = self._extras(dataset)
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     spatial = self._triple(g, dataset_ref, DCT.spatial, None)[2]
-    #     assert spatial
-    #     eq_(unicode(spatial), extras['spatial_uri'])
-    #     assert self._triple(g, spatial, RDF.type, DCT.Location)
-    #     assert self._triple(g, spatial, SKOS.prefLabel, extras['spatial_text'])
-
-    #     eq_(len([t for t in g.triples((spatial, LOCN.geometry, None))]), 2)
-    #     # Geometry in GeoJSON
-    #     assert self._triple(g, spatial, LOCN.geometry, extras['spatial'], GEOJSON_IMT)
-
-    #     # Geometry in WKT
-    #     wkt_geom = wkt.dumps(json.loads(extras['spatial']), decimals=4)
-    #     assert self._triple(g, spatial, LOCN.geometry, wkt_geom, GSP.wktLiteral)
-
-    # def test_spatial_bad_geojson_no_wkt(self):
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'extras': [
-    #             {'key': 'spatial', 'value': '{"key": "NotGeoJSON"}'},
-
-    #         ]
-    #     }
-    #     extras = self._extras(dataset)
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     spatial = self._triple(g, dataset_ref, DCT.spatial, None)[2]
-    #     assert spatial
-    #     assert_true(isinstance(spatial, BNode))
-    #     # Geometry in GeoJSON
-    #     assert self._triple(g, spatial, LOCN.geometry, extras['spatial'], GEOJSON_IMT)
-
-    #     # Geometry in WKT
-    #     eq_(len([t for t in g.triples((spatial, LOCN.geometry, None))]), 1)
-
-    # def test_distributions(self):
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             {
-    #                 'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #                 'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #                 'name': 'CSV file'
-    #             },
-    #             {
-    #                 'id': '8bceeda9-0084-477f-aa33-dad6148900d5',
-    #                 'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #                 'name': 'XLS file'
-    #             },
-    #             {
-    #                 'id': 'da73d939-0f11-45a1-9733-5de108383133',
-    #                 'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #                 'name': 'PDF file'
-    #             },
-
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     eq_(len([t for t in g.triples((dataset_ref, DCAT.distribution, None))]), 3)
-
-    #     for resource in dataset['resources']:
-    #         distribution = self._triple(g,
-    #                                     dataset_ref,
-    #                                     DCAT.distribution,
-    #                                     URIRef(utils.resource_uri(resource)))[2]
-
-    #         assert self._triple(g, distribution, RDF.type, DCAT.Distribution)
-    #         assert self._triple(g, distribution, DCT.title, resource['name'])
-
-    # def test_distribution_fields(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'description': 'A CSV file',
-    #         'url': 'http://example.com/data/file.csv',
-    #         'status': 'http://purl.org/adms/status/Completed',
-    #         'rights': 'Some statement about rights',
-    #         'license': 'http://creativecommons.org/licenses/by/3.0/',
-    #         'issued': '2015-06-26T15:21:09.034694',
-    #         'modified': '2015-06-26T15:21:09.075774',
-    #         'size': 1234,
-    #         'documentation': '[\"http://dataset.info.org/distribution1/doc1\", \"http://dataset.info.org/distribution1/doc2\"]',
-    #         'language': '[\"en\", \"es\", \"ca\"]',
-    #         'conforms_to': '[\"Standard 1\", \"Standard 2\"]',
-    #         'hash': '4304cf2e751e6053c90b1804c89c0ebb758f395a',
-    #         'hash_algorithm': 'http://spdx.org/rdf/terms#checksumAlgorithm_sha1',
-
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     eq_(len([t for t in g.triples((dataset_ref, DCAT.distribution, None))]), 1)
-
-    #     # URI
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-    #     eq_(unicode(distribution), utils.resource_uri(resource))
-
-    #     # Basic fields
-    #     assert self._triple(g, distribution, RDF.type, DCAT.Distribution)
-    #     assert self._triple(g, distribution, DCT.title, resource['name'])
-    #     assert self._triple(g, distribution, DCT.description, resource['description'])
-    #     assert self._triple(g, distribution, DCT.rights, resource['rights'])
-    #     assert self._triple(g, distribution, DCT.license, resource['license'])
-    #     assert self._triple(g, distribution, ADMS.status, resource['status'])
-
-    #     # List
-    #     for item in [
-    #         ('documentation', FOAF.page),
-    #         ('language', DCT.language),
-    #         ('conforms_to', DCT.conformsTo),
-    #     ]:
-    #         values = json.loads(resource[item[0]])
-    #         eq_(len([t for t in g.triples((distribution, item[1], None))]), len(values))
-    #         for value in values:
-    #             assert self._triple(g, distribution, item[1], value)
-
-    #     # Dates
-    #     assert self._triple(g, distribution, DCT.issued, resource['issued'], XSD.dateTime)
-    #     assert self._triple(g, distribution, DCT.modified, resource['modified'], XSD.dateTime)
-
-    #     # Numbers
-    #     assert self._triple(g, distribution, DCAT.byteSize, float(resource['size']), XSD.decimal)
-
-    #     # Checksum
-    #     checksum = self._triple(g, distribution, SPDX.checksum, None)[2]
-    #     assert checksum
-    #     assert self._triple(g, checksum, SPDX.checksumValue, resource['hash'], data_type='http://www.w3.org/2001/XMLSchema#hexBinary')
-    #     assert self._triple(g, checksum, SPDX.algorithm, URIRef(resource['hash_algorithm']))
-
-    # def test_distribution_access_url_only(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'url': 'http://example.com/data/file.csv',
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-
-    #     assert self._triple(g, distribution, DCAT.accessURL, URIRef(resource['url']))
-    #     assert self._triple(g, distribution, DCAT.downloadURL, None) is None
-
-    # def test_distribution_download_url_only(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'download_url': 'http://example.com/data/file.csv',
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-
-    #     assert self._triple(g, distribution, DCAT.downloadURL, URIRef(resource['download_url']))
-    #     assert self._triple(g, distribution, DCAT.accessURL, None) is None
-
-    # def test_distribution_both_urls_different(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'url': 'http://example.com/data/file',
-    #         'download_url': 'http://example.com/data/file.csv',
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-
-    #     assert self._triple(g, distribution, DCAT.accessURL, URIRef( resource['url']))
-    #     assert self._triple(g, distribution, DCAT.downloadURL, URIRef(resource['download_url']))
-
-    # def test_distribution_both_urls_the_same(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'url': 'http://example.com/data/file.csv',
-    #         'download_url': 'http://example.com/data/file.csv',
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-
-    #     assert self._triple(g, distribution, DCAT.downloadURL, URIRef(resource['url']))
-    #     assert self._triple(g, distribution, DCAT.accessURL, None) is None
-
-    # def test_distribution_format(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'url': 'http://example.com/data/file.csv',
-    #         'format': 'CSV',
-    #         'mimetype': 'text/csv',
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-
-    #     assert self._triple(g, distribution, DCT['format'], resource['format'])
-    #     assert self._triple(g, distribution, DCAT.mediaType, resource['mimetype'])
-
-    # def test_distribution_format_with_backslash(self):
-
-    #     resource = {
-    #         'id': 'c041c635-054f-4431-b647-f9186926d021',
-    #         'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'CSV file',
-    #         'url': 'http://example.com/data/file.csv',
-    #         'format': 'text/csv',
-    #     }
-
-    #     dataset = {
-    #         'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
-    #         'name': 'test-dataset',
-    #         'title': 'Test DCAT dataset',
-    #         'resources': [
-    #             resource
-    #         ]
-    #     }
-
-    #     s = RDFSerializer(profiles=['schemaorg'])
-    #     g = s.g
-
-    #     dataset_ref = s.graph_from_dataset(dataset)
-
-    #     distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
-
-    #     assert self._triple(g, distribution, DCAT.mediaType, resource['format'])
+    def test_publisher_extras(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'organization': {
+                'id': '',
+                'name': 'publisher1',
+                'title': 'Example Publisher from Org',
+            },
+            'extras': [
+                {'key': 'publisher_uri', 'value': 'http://example.com/publisher'},
+                {'key': 'publisher_name', 'value': 'Example Publisher'},
+                {'key': 'publisher_email', 'value': 'publisher@example.com'},
+                {'key': 'publisher_url', 'value': 'http://example.com/publisher/home'},
+                {'key': 'publisher_type', 'value': 'http://purl.org/adms/publishertype/Company'},
+            ]
+
+
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        publisher = self._triple(g, dataset_ref, SCHEMA.publisher, None)[2]
+        assert publisher
+        eq_(unicode(publisher), extras['publisher_uri'])
+        assert self._triple(g, publisher, RDF.type, SCHEMA.Organization)
+        assert self._triple(g, publisher, SCHEMA.name, extras['publisher_name'])
+
+        contact_point = self._triple(g, publisher, SCHEMA.contactPoint, None)[2]
+        assert contact_point
+        assert self._triple(g, contact_point, RDF.type, SCHEMA.ContactPoint)
+        assert self._triple(g, contact_point, SCHEMA.name, extras['publisher_name'])
+        assert self._triple(g, contact_point, SCHEMA.email, extras['publisher_email'])
+        assert self._triple(g, contact_point, SCHEMA.url, extras['publisher_url'])
+        assert self._triple(g, contact_point, SCHEMA.contactType, 'customer service')
+
+    def test_publisher_org(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'organization': {
+                'id': '',
+                'name': 'publisher1',
+                'title': 'Example Publisher from Org',
+            }
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        publisher = self._triple(g, dataset_ref, SCHEMA.publisher, None)[2]
+        assert publisher
+        assert self._triple(g, publisher, RDF.type, SCHEMA.Organization)
+        assert self._triple(g, publisher, SCHEMA.name, dataset['organization']['title'])
+
+    def test_temporal_start_and_end(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'extras': [
+                {'key': 'temporal_start', 'value': '2015-06-26T15:21:09.075774'},
+                {'key': 'temporal_end', 'value': '2015-07-14'},
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        assert self._triple(g, dataset_ref, SCHEMA.temporalCoverage, '2015-06-26T15:21:09.075774/2015-07-14')
+
+    def test_temporal_start_only(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'extras': [
+                {'key': 'temporal_start', 'value': '2015-06-26T15:21:09.075774'},
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        assert self._triple(g, dataset_ref, SCHEMA.temporalCoverage, parse_date(extras['temporal_start']).isoformat(), SCHEMA.DateTime)
+
+    def test_spatial(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'extras': [
+                {'key': 'spatial_uri', 'value': 'http://sws.geonames.org/6361390/'},
+                {'key': 'spatial_text', 'value': 'Tarragona'},
+                {'key': 'spatial', 'value': '{"type": "Polygon", "coordinates": [[[1.1870606,41.0786393],[1.1870606,41.1655218],[1.3752339,41.1655218],[1.3752339,41.0786393],[1.1870606,41.0786393]]]}'},
+
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        spatial = self._triple(g, dataset_ref, SCHEMA.spatialCoverage, None)[2]
+        assert spatial
+        eq_(unicode(spatial), extras['spatial_uri'])
+        assert self._triple(g, spatial, RDF.type, SCHEMA.Place)
+        assert self._triple(g, spatial, SCHEMA.description, extras['spatial_text'])
+        geo = self._triple(g, spatial, SCHEMA.geo, None)[2]
+        assert self._triple(g, geo, RDF.type, SCHEMA.GeoShape)
+        assert self._triple(g, geo, SCHEMA.polygon, extras['spatial'])
+
+    def test_distributions(self):
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                {
+                    'id': 'c041c635-054f-4431-b647-f9186926d021',
+                    'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+                    'name': 'CSV file'
+                },
+                {
+                    'id': '8bceeda9-0084-477f-aa33-dad6148900d5',
+                    'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+                    'name': 'XLS file'
+                },
+                {
+                    'id': 'da73d939-0f11-45a1-9733-5de108383133',
+                    'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+                    'name': 'PDF file'
+                },
+
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        eq_(len([t for t in g.triples((dataset_ref, SCHEMA.distribution, None))]), 3)
+
+        for resource in dataset['resources']:
+            distribution = self._triple(g,
+                                        dataset_ref,
+                                        SCHEMA.distribution,
+                                        URIRef(utils.resource_uri(resource)))[2]
+
+            assert self._triple(g, distribution, RDF.type, SCHEMA.DataDownload)
+            assert self._triple(g, distribution, SCHEMA.name, resource['name'])
+
+    def test_distribution_fields(self):
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'description': 'A CSV file',
+            'url': 'http://example.com/data/file.csv',
+            'status': 'http://purl.org/adms/status/Completed',
+            'rights': 'Some statement about rights',
+            'license': 'http://creativecommons.org/licenses/by/3.0/',
+            'issued': '2015-06-26T15:21:09.034694',
+            'modified': '2015-06-26T15:21:09.075774',
+            'size': 1234,
+            'language': '[\"en\", \"es\", \"ca\"]',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        eq_(len([t for t in g.triples((dataset_ref, SCHEMA.distribution, None))]), 1)
+
+        # URI
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+        eq_(unicode(distribution), utils.resource_uri(resource))
+
+        # Basic fields
+        assert self._triple(g, distribution, RDF.type, SCHEMA.DataDownload)
+        assert self._triple(g, distribution, SCHEMA.name, resource['name'])
+        assert self._triple(g, distribution, SCHEMA.description, resource['description'])
+        assert self._triple(g, distribution, SCHEMA.license, resource['license'])
+
+        # List
+        for item in [
+            ('language', SCHEMA.inLanguage),
+        ]:
+            values = json.loads(resource[item[0]])
+            eq_(len([t for t in g.triples((distribution, item[1], None))]), len(values))
+            for value in values:
+                assert self._triple(g, distribution, item[1], value)
+
+        # Dates
+        assert self._triple(g, distribution, SCHEMA.datePublished, resource['issued'], SCHEMA.DateTime)
+        assert self._triple(g, distribution, SCHEMA.dateModified, resource['modified'], SCHEMA.DateTime)
+
+        # Numbers
+        assert self._triple(g, distribution, SCHEMA.contentSize, resource['size'])
+
+    def test_distribution_access_url_only(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'url': 'http://example.com/data/file.csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.url, resource['url'])
+        assert self._triple(g, distribution, SCHEMA.contentUrl, None) is None
+
+    def test_distribution_download_url_only(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'download_url': 'http://example.com/data/file.csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.contentUrl, resource['download_url'])
+        assert self._triple(g, distribution, SCHEMA.url, None) is None
+
+    def test_distribution_both_urls_different(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'url': 'http://example.com/data/file',
+            'download_url': 'http://example.com/data/file.csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.url, resource['url'])
+        assert self._triple(g, distribution, SCHEMA.contentUrl, resource['download_url'])
+
+    def test_distribution_both_urls_the_same(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'url': 'http://example.com/data/file.csv',
+            'download_url': 'http://example.com/data/file.csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.contentUrl, resource['url'])
+        assert self._triple(g, distribution, SCHEMA.url, None) is None
+
+    def test_distribution_format(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'url': 'http://example.com/data/file.csv',
+            'format': 'CSV',
+            'mimetype': 'text/csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.encodingFormat, resource['format'])
+        assert self._triple(g, distribution, SCHEMA.fileType, resource['mimetype'])
+
+    def test_distribution_format_with_backslash(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'url': 'http://example.com/data/file.csv',
+            'format': 'text/csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.fileType, resource['format'])
+        assert self._triple(g, distribution, SCHEMA.encodingFormat, resource['format'])
 

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -70,8 +70,8 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, SCHEMA.identifier, extras['identifier'])
 
         # Dates
-        assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'], SCHEMA.DateTime)
-        assert self._triple(g, dataset_ref, SCHEMA.dateModified, dataset['metadata_modified'], SCHEMA.DateTime)
+        assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'])
+        assert self._triple(g, dataset_ref, SCHEMA.dateModified, dataset['metadata_modified'])
 
         # Tags
         eq_(len([t for t in g.triples((dataset_ref, SCHEMA.keywords, None))]), 2)
@@ -182,7 +182,7 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
 
         dataset_ref = s.graph_from_dataset(dataset)
 
-        assert self._triple(g, dataset_ref, SCHEMA.temporalCoverage, parse_date(extras['temporal_start']).isoformat(), SCHEMA.DateTime)
+        assert self._triple(g, dataset_ref, SCHEMA.temporalCoverage, parse_date(extras['temporal_start']).isoformat())
 
     def test_spatial(self):
         dataset = {
@@ -305,8 +305,8 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
                 assert self._triple(g, distribution, item[1], value)
 
         # Dates
-        assert self._triple(g, distribution, SCHEMA.datePublished, resource['issued'], SCHEMA.DateTime)
-        assert self._triple(g, distribution, SCHEMA.dateModified, resource['modified'], SCHEMA.DateTime)
+        assert self._triple(g, distribution, SCHEMA.datePublished, resource['issued'])
+        assert self._triple(g, distribution, SCHEMA.dateModified, resource['modified'])
 
         # Numbers
         assert self._triple(g, distribution, SCHEMA.contentSize, resource['size'])

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+import json
 
 from pylons import config
 
@@ -59,6 +60,34 @@ def field_labels():
         'created': _('Created'),
     }
 
+
+def structured_data(dataset_id, profiles=None, _format='jsonld'):
+    '''
+    Returns a string containing the structured data of the given
+    dataset id and using the given profiles (if no profiles are supplied
+    the default profiles are used).
+
+    This string can be used in the frontend.
+    '''
+    if not profiles:
+        profiles = ['schemaorg']
+
+    data = toolkit.get_action('dcat_dataset_show')(
+        {},
+        {
+            'id': dataset_id, 
+            'profiles': profiles, 
+            'format': _format, 
+        }
+    )
+    # parse result again to prevent UnicodeDecodeError and add formatting
+    try:
+        json_data = json.loads(data)
+        return json.dumps(json_data, sort_keys=True,
+                          indent=4, separators=(',', ': '))
+    except ValueError:
+        # result was not JSON, return anyway
+        return data
 
 def catalog_uri():
     '''

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -2,7 +2,15 @@ import logging
 import uuid
 import json
 
-from pylons import config
+from ckantoolkit import config, h
+
+try:
+    # CKAN >= 2.6
+    from ckan.exceptions import HelperError
+except ImportError:
+    # CKAN < 2.6
+    class HelperError(Exception):
+        pass
 
 from ckan import model
 import ckan.plugins.toolkit as toolkit
@@ -60,6 +68,15 @@ def field_labels():
         'created': _('Created'),
     }
 
+def helper_available(helper_name):
+    '''
+    Checks if a given helper name is available on `h`
+    '''
+    try:
+        getattr(h, helper_name)
+    except (AttributeError, HelperError):
+        return False
+    return True
 
 def structured_data(dataset_id, profiles=None, _format='jsonld'):
     '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 rdflib==4.2.1
 rdflib-jsonld==0.4.0
 git+https://github.com/geomet/geomet.git
+ckantoolkit==0.0.3

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
 
     dcat=ckanext.dcat.plugins:DCATPlugin
 
-    schemaorg=ckanext.dcat.plugins.SchemaOrgPlugin
+    structured_data=ckanext.dcat.plugins:StructuredDataPlugin
 
     # Test plugins
     test_rdf_harvester=ckanext.dcat.tests.test_harvester:TestRDFHarvester

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
 
     [ckan.rdf.profiles]
     euro_dcat_ap=ckanext.dcat.profiles:EuropeanDCATAPProfile
-    euro_dcat_ap=ckanext.dcat.profiles:EuropeanDCATAPProfile
     schemaorg=ckanext.dcat.profiles:SchemaOrgProfile
 
     [paste.paster_command]

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
 
     dcat=ckanext.dcat.plugins:DCATPlugin
 
+    schemaorg=ckanext.dcat.plugins.SchemaOrgPlugin
+
     # Test plugins
     test_rdf_harvester=ckanext.dcat.tests.test_harvester:TestRDFHarvester
     test_rdf_null_harvester=ckanext.dcat.tests.test_harvester:TestRDFNullHarvester
@@ -40,6 +42,8 @@ setup(
 
     [ckan.rdf.profiles]
     euro_dcat_ap=ckanext.dcat.profiles:EuropeanDCATAPProfile
+    euro_dcat_ap=ckanext.dcat.profiles:EuropeanDCATAPProfile
+    schemaorg=ckanext.dcat.profiles:SchemaOrgProfile
 
     [paste.paster_command]
     generate_static = ckanext.dcat.commands:GenerateStaticDCATCommand

--- a/test.ini
+++ b/test.ini
@@ -11,7 +11,7 @@ port = 5000
 [app:main]
 use = config:../ckan/test-core.ini
 solr_url = http://127.0.0.1:8983/solr
-ckan.plugins = dcat harvest dcat_rdf_harvester
+ckan.plugins = dcat harvest dcat_rdf_harvester structured_data
 ckan.harvest.mq.type = redis
 ckanext.dcat.enable_content_negotiation=True
 


### PR DESCRIPTION
Add schema.org mapping (see #75 for details)

This PR provides:
* Mapping from DCAT to schema.org/Dataset
* New parameter `profiles` to the catalog and dataset endpoints to be able to change the profiles when requesting the metadata (this allows to server DCAT and schema.org on the same instance), example `/dataset/my-dataset.jsonld?profiles=schemaorg`