### PR TITLE
Remove dependency on ckanext-harvest

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -13,7 +13,7 @@ from geomet import wkt, InvalidGeoJSONException
 
 from ckan.model.license import LicenseRegister
 from ckan.plugins import toolkit
-from ckanext.harvest.harvesters.base import munge_tag
+from ckan.lib.munge import munge_tag
 
 from ckanext.dcat.utils import resource_uri, publisher_uri_from_dataset_dict, DCAT_EXPOSE_SUBCATALOGS, DCAT_CLEAN_TAGS
 


### PR DESCRIPTION
It doesn't seem right to assume that ckanext-harvest is available - sure, many use dcat for harvesting but you can also use it just for offering dcat. The only reason I can see for importing from ckanext-harvest is to support very, very old CKANs (https://github.com/ckan/ckanext-harvest/blob/master/ckanext/harvest/harvesters/base.py#L24).