### PR TITLE
Json harvester reorg

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -51,3 +51,224 @@ class DCATJSONHarvester(DCATHarvester):
         package_dict = converters.dcat_to_ckan(dcat_dict)
 
         return package_dict, dcat_dict
+
+    def gather_stage(self, harvest_job):
+        log.debug('In DCATJSONHarvester gather_stage')
+
+        ids = []
+
+        # Get the previous guids for this source
+        query = \
+            model.Session.query(HarvestObject.guid, HarvestObject.package_id) \
+            .filter(HarvestObject.current == True) \
+            .filter(HarvestObject.harvest_source_id == harvest_job.source.id)
+        guid_to_package_id = {}
+
+        for guid, package_id in query:
+            guid_to_package_id[guid] = package_id
+
+        guids_in_db = guid_to_package_id.keys()
+        guids_in_source = []
+
+        # Get file contents
+        url = harvest_job.source.url
+
+        previous_guids = []
+        page = 1
+        while True:
+
+            try:
+                content, content_type = \
+                    self._get_content_and_type(url, harvest_job, page)
+            except requests.exceptions.HTTPError, error:
+                if error.response.status_code == 404:
+                    if page > 1:
+                        # Server returned a 404 after the first page, no more
+                        # records
+                        log.debug('404 after first page, no more pages')
+                        break
+                    else:
+                        # Proper 404
+                        msg = 'Could not get content. Server responded with ' \
+                            '404 Not Found'
+                        self._save_gather_error(msg, harvest_job)
+                        return None
+                else:
+                    # This should never happen. Raising just in case.
+                    raise
+
+            if not content:
+                return None
+
+            try:
+
+                batch_guids = []
+                for guid, as_string in self._get_guids_and_datasets(content):
+
+                    log.debug('Got identifier: {0}'
+                              .format(guid.encode('utf8')))
+                    batch_guids.append(guid)
+
+                    if guid not in previous_guids:
+
+                        if guid in guids_in_db:
+                            # Dataset needs to be udpated
+                            obj = HarvestObject(
+                                guid=guid, job=harvest_job,
+                                package_id=guid_to_package_id[guid],
+                                content=as_string,
+                                extras=[HarvestObjectExtra(key='status',
+                                                           value='change')])
+                        else:
+                            # Dataset needs to be created
+                            obj = HarvestObject(
+                                guid=guid, job=harvest_job,
+                                content=as_string,
+                                extras=[HarvestObjectExtra(key='status',
+                                                           value='new')])
+                        obj.save()
+                        ids.append(obj.id)
+
+                if len(batch_guids) > 0:
+                    guids_in_source.extend(set(batch_guids)
+                                           - set(previous_guids))
+                else:
+                    log.debug('Empty document, no more records')
+                    # Empty document, no more ids
+                    break
+
+            except ValueError, e:
+                msg = 'Error parsing file: {0}'.format(str(e))
+                self._save_gather_error(msg, harvest_job)
+                return None
+
+            if sorted(previous_guids) == sorted(batch_guids):
+                # Server does not support pagination or no more pages
+                log.debug('Same content, no more pages')
+                break
+
+            page = page + 1
+
+            previous_guids = batch_guids
+
+        # Check datasets that need to be deleted
+        guids_to_delete = set(guids_in_db) - set(guids_in_source)
+        for guid in guids_to_delete:
+            obj = HarvestObject(
+                guid=guid, job=harvest_job,
+                package_id=guid_to_package_id[guid],
+                extras=[HarvestObjectExtra(key='status', value='delete')])
+            ids.append(obj.id)
+            model.Session.query(HarvestObject).\
+                filter_by(guid=guid).\
+                update({'current': False}, False)
+            obj.save()
+
+        return ids
+
+    def fetch_stage(self, harvest_object):
+        return True
+
+    def import_stage(self, harvest_object):
+        log.debug('In DCATJSONHarvester import_stage')
+        if not harvest_object:
+            log.error('No harvest object received')
+            return False
+
+        if self.force_import:
+            status = 'change'
+        else:
+            status = self._get_object_extra(harvest_object, 'status')
+
+        if status == 'delete':
+            # Delete package
+            context = {'model': model, 'session': model.Session,
+                       'user': self._get_user_name()}
+
+            p.toolkit.get_action('package_delete')(
+                context, {'id': harvest_object.package_id})
+            log.info('Deleted package {0} with guid {1}'
+                     .format(harvest_object.package_id, harvest_object.guid))
+
+            return True
+
+        if harvest_object.content is None:
+            self._save_object_error(
+                'Empty content for object %s' % harvest_object.id,
+                harvest_object, 'Import')
+            return False
+
+        # Get the last harvested object (if any)
+        previous_object = model.Session.query(HarvestObject) \
+            .filter(HarvestObject.guid == harvest_object.guid) \
+            .filter(HarvestObject.current == True) \
+            .first()
+
+        # Flag previous object as not current anymore
+        if previous_object and not self.force_import:
+            previous_object.current = False
+            previous_object.add()
+
+        package_dict, dcat_dict = self._get_package_dict(harvest_object)
+        if not package_dict:
+            return False
+
+        if not package_dict.get('name'):
+            package_dict['name'] = \
+                self._get_package_name(harvest_object, package_dict['title'])
+
+        # Allow custom harvesters to modify the package dict before creating
+        # or updating the package
+        package_dict = self.modify_package_dict(package_dict,
+                                                dcat_dict,
+                                                harvest_object)
+        # Unless already set by an extension, get the owner organization (if
+        # any) from the harvest source dataset
+        if not package_dict.get('owner_org'):
+            source_dataset = model.Package.get(harvest_object.source.id)
+            if source_dataset.owner_org:
+                package_dict['owner_org'] = source_dataset.owner_org
+
+        # Flag this object as the current one
+        harvest_object.current = True
+        harvest_object.add()
+
+        context = {
+            'user': self._get_user_name(),
+            'return_id_only': True,
+            'ignore_auth': True,
+        }
+
+        if status == 'new':
+
+            package_schema = logic.schema.default_create_package_schema()
+            context['schema'] = package_schema
+
+            # We need to explicitly provide a package ID
+            package_dict['id'] = unicode(uuid.uuid4())
+            package_schema['id'] = [unicode]
+
+            # Save reference to the package on the object
+            harvest_object.package_id = package_dict['id']
+            harvest_object.add()
+
+            # Defer constraints and flush so the dataset can be indexed with
+            # the harvest object id (on the after_show hook from the harvester
+            # plugin)
+            model.Session.execute(
+                'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
+            model.Session.flush()
+
+            package_id = \
+                p.toolkit.get_action('package_create')(context, package_dict)
+            log.info('Created dataset with id %s', package_id)
+
+        elif status == 'change':
+            package_dict['id'] = harvest_object.package_id
+            package_id = \
+                p.toolkit.get_action('package_update')(context, package_dict)
+            log.info('Updated dataset with id %s', package_id)
+
+        model.Session.commit()
+
+        return True

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -1,6 +1,12 @@
 import json
 import logging
 from hashlib import sha1
+import uuid
+
+from ckan import model
+from ckan import logic
+from ckan import plugins as p
+from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 
 from ckanext.dcat import converters
 from ckanext.dcat.harvesters.base import DCATHarvester

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -28,8 +28,8 @@ class DCATHarvester(HarvesterBase):
 
     _user_name = None
 
-
-    def _get_content_and_type(self, url, harvest_job, page=1, content_type=None):
+    def _get_content_and_type(self, url, harvest_job, page=1,
+                              content_type=None):
         '''
         Gets the content and type of the given url.
 
@@ -48,7 +48,8 @@ class DCATHarvester(HarvesterBase):
                 content_type = content_type or rdflib.util.guess_format(url)
                 return content, content_type
             else:
-                self._save_gather_error('Could not get content for this url', harvest_job)
+                self._save_gather_error('Could not get content for this url',
+                                        harvest_job)
                 return None, None
 
         try:
@@ -56,9 +57,8 @@ class DCATHarvester(HarvesterBase):
                 url = url + '&' if '?' in url else url + '?'
                 url = url + 'page={0}'.format(page)
 
-
             log.debug('Getting file %s', url)
-            
+
             # get the `requests` session object
             session = requests.Session()
             for harvester in p.PluginImplementations(IDCATRDFHarvester):
@@ -90,7 +90,8 @@ class DCATHarvester(HarvesterBase):
                 length += len(chunk)
 
                 if length >= self.MAX_FILE_SIZE:
-                    self._save_gather_error('Remote file is too big.', harvest_job)
+                    self._save_gather_error('Remote file is too big.',
+                                            harvest_job)
                     return None, None
 
             if content_type is None and r.headers.get('content-type'):
@@ -103,8 +104,8 @@ class DCATHarvester(HarvesterBase):
                 # We want to catch these ones later on
                 raise
 
-            msg = 'Could not get content from %s. Server responded with %s %s' % (
-                url, error.response.status_code, error.response.reason)
+            msg = 'Could not get content from %s. Server responded with %s %s'\
+                % (url, error.response.status_code, error.response.reason)
             self._save_gather_error(msg, harvest_job)
             return None, None
         except requests.exceptions.ConnectionError, error:
@@ -113,7 +114,8 @@ class DCATHarvester(HarvesterBase):
             self._save_gather_error(msg, harvest_job)
             return None, None
         except requests.exceptions.Timeout, error:
-            msg = 'Could not get content from %s because the connection timed out.' % url
+            msg = 'Could not get content from %s because the connection timed'\
+                ' out.' % url
             self._save_gather_error(msg, harvest_job)
             return None, None
 
@@ -144,21 +146,23 @@ class DCATHarvester(HarvesterBase):
         if package is None or package.title != title:
             name = self._gen_new_name(title)
             if not name:
-                raise Exception('Could not generate a unique name from the title or the GUID. Please choose a more unique title.')
+                raise Exception(
+                    'Could not generate a unique name from the title or the '
+                    'GUID. Please choose a more unique title.')
         else:
             name = package.name
 
         return name
 
     def get_original_url(self, harvest_object_id):
-        obj = model.Session.query(HarvestObject).\
-                                    filter(HarvestObject.id==harvest_object_id).\
-                                    first()
+        obj = model.Session.query(HarvestObject). \
+            filter(HarvestObject.id == harvest_object_id).\
+            first()
         if obj:
             return obj.source.url
         return None
 
-    ## Start hooks
+    # Start hooks
 
     def modify_package_dict(self, package_dict, dcat_dict, harvest_object):
         '''
@@ -167,214 +171,4 @@ class DCATHarvester(HarvesterBase):
         '''
         return package_dict
 
-    ## End hooks
-
-    def gather_stage(self,harvest_job):
-        log.debug('In DCATHarvester gather_stage')
-
-
-        ids = []
-
-        # Get the previous guids for this source
-        query = model.Session.query(HarvestObject.guid, HarvestObject.package_id).\
-                                    filter(HarvestObject.current==True).\
-                                    filter(HarvestObject.harvest_source_id==harvest_job.source.id)
-        guid_to_package_id = {}
-
-        for guid, package_id in query:
-            guid_to_package_id[guid] = package_id
-
-        guids_in_db = guid_to_package_id.keys()
-        guids_in_source = []
-
-
-        # Get file contents
-        url = harvest_job.source.url
-
-        previous_guids = []
-        page = 1
-        while True:
-
-            try:
-                content, content_type = self._get_content_and_type(url, harvest_job, page)
-            except requests.exceptions.HTTPError, error:
-                if error.response.status_code == 404:
-                    if page > 1:
-                        # Server returned a 404 after the first page, no more
-                        # records
-                        log.debug('404 after first page, no more pages')
-                        break
-                    else:
-                        # Proper 404
-                        msg = 'Could not get content. Server responded with 404 Not Found'
-                        self._save_gather_error(msg, harvest_job)
-                        return None
-                else:
-                    # This should never happen. Raising just in case.
-                    raise
-
-            if not content:
-                return None
-
-
-            try:
-
-                batch_guids = []
-                for guid, as_string in self._get_guids_and_datasets(content):
-
-                    log.debug('Got identifier: {0}'.format(guid.encode('utf8')))
-                    batch_guids.append(guid)
-
-                    if guid not in previous_guids:
-
-                        if guid in guids_in_db:
-                            # Dataset needs to be udpated
-                            obj = HarvestObject(guid=guid, job=harvest_job,
-                                            package_id=guid_to_package_id[guid],
-                                            content=as_string,
-                                            extras=[HarvestObjectExtra(key='status', value='change')])
-                        else:
-                            # Dataset needs to be created
-                            obj = HarvestObject(guid=guid, job=harvest_job,
-                                            content=as_string,
-                                            extras=[HarvestObjectExtra(key='status', value='new')])
-                        obj.save()
-                        ids.append(obj.id)
-
-                if len(batch_guids) > 0:
-                    guids_in_source.extend(set(batch_guids) - set(previous_guids))
-                else:
-                    log.debug('Empty document, no more records')
-                    # Empty document, no more ids
-                    break
-
-            except ValueError, e:
-                msg = 'Error parsing file: {0}'.format(str(e))
-                self._save_gather_error(msg, harvest_job)
-                return None
-
-            if sorted(previous_guids) == sorted(batch_guids):
-                # Server does not support pagination or no more pages
-                log.debug('Same content, no more pages')
-                break
-
-
-            page = page + 1
-
-            previous_guids = batch_guids
-
-        # Check datasets that need to be deleted
-        guids_to_delete = set(guids_in_db) - set(guids_in_source)
-        for guid in guids_to_delete:
-            obj = HarvestObject(guid=guid, job=harvest_job,
-                                package_id=guid_to_package_id[guid],
-                                extras=[HarvestObjectExtra(key='status', value='delete')])
-            ids.append(obj.id)
-            model.Session.query(HarvestObject).\
-                  filter_by(guid=guid).\
-                  update({'current': False}, False)
-            obj.save()
-
-
-        return ids
-
-    def fetch_stage(self,harvest_object):
-        return True
-
-    def import_stage(self,harvest_object):
-        log.debug('In DCATHarvester import_stage')
-        if not harvest_object:
-            log.error('No harvest object received')
-            return False
-
-        if self.force_import:
-            status = 'change'
-        else:
-            status = self._get_object_extra(harvest_object, 'status')
-
-        if status == 'delete':
-            # Delete package
-            context = {'model': model, 'session': model.Session, 'user': self._get_user_name()}
-
-            p.toolkit.get_action('package_delete')(context, {'id': harvest_object.package_id})
-            log.info('Deleted package {0} with guid {1}'.format(harvest_object.package_id, harvest_object.guid))
-
-            return True
-
-
-        if harvest_object.content is None:
-            self._save_object_error('Empty content for object %s' % harvest_object.id,harvest_object,'Import')
-            return False
-
-        # Get the last harvested object (if any)
-        previous_object = model.Session.query(HarvestObject) \
-                          .filter(HarvestObject.guid==harvest_object.guid) \
-                          .filter(HarvestObject.current==True) \
-                          .first()
-
-        # Flag previous object as not current anymore
-        if previous_object and not self.force_import:
-            previous_object.current = False
-            previous_object.add()
-
-
-        package_dict, dcat_dict = self._get_package_dict(harvest_object)
-        if not package_dict:
-            return False
-
-        if not package_dict.get('name'):
-            package_dict['name'] = self._get_package_name(harvest_object, package_dict['title'])
-
-        # Allow custom harvesters to modify the package dict before creating
-        # or updating the package
-        package_dict = self.modify_package_dict(package_dict,
-                                                dcat_dict,
-                                                harvest_object)
-        # Unless already set by an extension, get the owner organization (if any)
-        # from the harvest source dataset
-        if not package_dict.get('owner_org'):
-            source_dataset = model.Package.get(harvest_object.source.id)
-            if source_dataset.owner_org:
-                package_dict['owner_org'] = source_dataset.owner_org
-
-        # Flag this object as the current one
-        harvest_object.current = True
-        harvest_object.add()
-
-        context = {
-            'user': self._get_user_name(),
-            'return_id_only': True,
-            'ignore_auth': True,
-        }
-
-        if status == 'new':
-
-
-            package_schema = logic.schema.default_create_package_schema()
-            context['schema'] = package_schema
-
-            # We need to explicitly provide a package ID
-            package_dict['id'] = unicode(uuid.uuid4())
-            package_schema['id'] = [unicode]
-
-            # Save reference to the package on the object
-            harvest_object.package_id = package_dict['id']
-            harvest_object.add()
-
-            # Defer constraints and flush so the dataset can be indexed with
-            # the harvest object id (on the after_show hook from the harvester
-            # plugin)
-            model.Session.execute('SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
-            model.Session.flush()
-
-            package_id = p.toolkit.get_action('package_create')(context, package_dict)
-            log.info('Created dataset with id %s', package_id)
-        elif status == 'change':
-
-            package_dict['id'] = harvest_object.package_id
-            package_id = p.toolkit.get_action('package_update')(context, package_dict)
-            log.info('Updated dataset with id %s', package_id)
-
-        model.Session.commit()
-
-        return True
+    # End hooks

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -12,7 +12,7 @@ import ckantoolkit.tests.helpers as h
 import ckanext.harvest.model as harvest_model
 from ckanext.harvest import queue
 
-from ckanext.dcat.harvesters import DCATRDFHarvester
+from ckanext.dcat.harvesters import DCATRDFHarvester, DCATJSONHarvester
 from ckanext.dcat.interfaces import IDCATRDFHarvester
 import ckanext.dcat.harvesters.rdf
 
@@ -26,20 +26,33 @@ eq_ = nose.tools.eq_
 
 # Start monkey-patch
 
-original_get_content_and_type = DCATRDFHarvester._get_content_and_type
+original_rdf_get_content_and_type = DCATRDFHarvester._get_content_and_type
 
-
-def _patched_get_content_and_type(self, url, harvest_job, page=1, content_type=None):
+def _patched_rdf_get_content_and_type(self, url, harvest_job, page=1, content_type=None):
 
     httpretty.enable()
 
-    value1, value2 = original_get_content_and_type(self, url, harvest_job, page, content_type)
+    value1, value2 = original_rdf_get_content_and_type(self, url, harvest_job, page, content_type)
 
     httpretty.disable()
 
     return value1, value2
 
-DCATRDFHarvester._get_content_and_type = _patched_get_content_and_type
+DCATRDFHarvester._get_content_and_type = _patched_rdf_get_content_and_type
+
+original_json_get_content_and_type = DCATJSONHarvester._get_content_and_type
+
+def _patched_json_get_content_and_type(self, url, harvest_job, page=1, content_type=None):
+
+    httpretty.enable()
+
+    value1, value2 = original_json_get_content_and_type(self, url, harvest_job, page, content_type)
+
+    httpretty.disable()
+
+    return value1, value2
+
+DCATJSONHarvester._get_content_and_type = _patched_json_get_content_and_type
 
 # End monkey-patch
 
@@ -498,8 +511,6 @@ class FunctionalHarvestTest(object):
         harvest_source = h.call_action('harvest_source_create',
                                        {}, **source_dict)
 
-        eq_(harvest_source['source_type'], 'dcat_rdf')
-
         return harvest_source
 
     def _create_harvest_job(self, harvest_source_id):
@@ -791,7 +802,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         results = h.call_action('package_search', {}, fq=fq)
         eq_(results['count'], 1)
 
-	existing_dataset = results['results'][0]
+        existing_dataset = results['results'][0]
         existing_resource = existing_dataset.get('resources')[0]
 
         # Mock an update in the remote file
@@ -807,8 +818,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         new_results = h.call_action('package_search', {}, fq=fq)
         eq_(new_results['count'], 1)
 
-	new_dataset = new_results['results'][0]
-	new_resource = new_dataset.get('resources')[0]
+        new_dataset = new_results['results'][0]
+        new_resource = new_dataset.get('resources')[0]
 
         eq_(existing_resource['name'], 'Example resource 1')
         eq_(len(new_dataset.get('resources')), 1)

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -1,0 +1,71 @@
+import httpretty
+import nose
+
+import ckantoolkit.tests.helpers as h
+
+from test_harvester import FunctionalHarvestTest
+
+eq_ = nose.tools.eq_
+
+class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
+
+    @classmethod
+    def setup_class(cls):
+        super(TestDCATJSONHarvestFunctional, cls).setup_class()
+
+        # Remote DCAT JSON / data.json file
+        cls.json_mock_url = 'http://some.dcat.file.json'
+        cls.json_content_type = 'application/json'
+
+        # minimal dataset
+        cls.json_content = '''
+{
+  "dataset":[
+    {"@type": "dcat:Dataset",
+     "identifier": "http://example.com/datasets/example1",
+     "title": "Example dataset 1",
+     "description": "Lots of species",
+     "publisher": {"name": "Example Department of Wildlife"},
+     "license": "https://example.com/license"
+    },
+    {"@type": "dcat:Dataset",
+     "identifier": "http://example.com/datasets/example1",
+     "title": "Example dataset 2",
+     "description": "More species",
+     "publisher": {"name":"Example Department of Wildlife"},
+     "license": "https://example.com/license"
+    }
+  ]
+}
+        '''
+
+    def test_harvest_create(self):
+
+        self._test_harvest_create(self.json_mock_url,
+                                  self.json_content,
+                                  self.json_content_type)
+
+    def _test_harvest_create(self, url, content, content_type, num_datasets=2,
+                             **kwargs):
+
+        # Mock the GET request to get the file
+        httpretty.register_uri(httpretty.GET, url,
+                               body=content, content_type=content_type)
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well
+        httpretty.register_uri(httpretty.HEAD, url,
+                               status=405, content_type=content_type)
+
+        kwargs['source_type'] = 'dcat_json'
+        harvest_source = self._create_harvest_source(url, **kwargs)
+
+        self._run_full_job(harvest_source['id'], num_objects=num_datasets)
+
+        fq = "+type:dataset harvest_source_id:{0}".format(harvest_source['id'])
+        results = h.call_action('package_search', {}, fq=fq)
+
+        eq_(results['count'], num_datasets)
+        for result in results['results']:
+            assert result['title'] in ('Example dataset 1',
+                                       'Example dataset 2')

--- a/test.ini
+++ b/test.ini
@@ -11,7 +11,7 @@ port = 5000
 [app:main]
 use = config:../ckan/test-core.ini
 solr_url = http://127.0.0.1:8983/solr
-ckan.plugins = dcat harvest dcat_rdf_harvester structured_data
+ckan.plugins = dcat harvest dcat_rdf_harvester dcat_json_harvester structured_data
 ckan.harvest.mq.type = redis
 ckanext.dcat.enable_content_negotiation=True
 


### PR DESCRIPTION
The gather/fetch/import_stage methods for the json harvester has been sitting in the base class DCATHarvester, also inherited by the DCATRDFHarvester, but that has it's own version of those methods, so it seems pretty safe to move them.

I added in the tests from #115 to check this works. This PR should probably be merged before that one and then I can sort out the conflicts.