### PR TITLE
Use encodingFormat for schemaorg

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1376,19 +1376,12 @@ class SchemaOrgProfile(RDFProfile):
         self._add_list_triples_from_dict(resource_dict, distribution, items)
 
     def _distribution_format_graph(self, distribution, resource_dict):
-        if '/' in resource_dict.get('format', ''):
-            self.g.add((distribution, SCHEMA.fileType,
-                   Literal(resource_dict['format'])))
+        if resource_dict.get('format'):
             self.g.add((distribution, SCHEMA.encodingFormat,
                    Literal(resource_dict['format'])))
-        else:
-            if resource_dict.get('format'):
-                self.g.add((distribution, SCHEMA.encodingFormat,
-                       Literal(resource_dict['format'])))
-
-            if resource_dict.get('mimetype'):
-                self.g.add((distribution, SCHEMA.fileType,
-                       Literal(resource_dict['mimetype'])))
+        elif resource_dict.get('mimetype'):
+            self.g.add((distribution, SCHEMA.encodingFormat,
+                   Literal(resource_dict['mimetype'])))
 
     def _distribution_url_graph(self, distribution, resource_dict):
         url = resource_dict.get('url')

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -453,7 +453,35 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
 
         assert self._triple(g, distribution, SCHEMA.encodingFormat, resource['format'])
-        assert self._triple(g, distribution, SCHEMA.fileType, resource['mimetype'])
+
+    def test_distribution_format_with_mimetype_fallback(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'CSV file',
+            'url': 'http://example.com/data/file.csv',
+            'format': '',
+            'mimetype': 'text/csv',
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
+
+        assert self._triple(g, distribution, SCHEMA.encodingFormat, resource['mimetype'])
 
     def test_distribution_format_with_backslash(self):
 
@@ -481,6 +509,5 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
 
         distribution = self._triple(g, dataset_ref, SCHEMA.distribution, None)[2]
 
-        assert self._triple(g, distribution, SCHEMA.fileType, resource['format'])
         assert self._triple(g, distribution, SCHEMA.encodingFormat, resource['format'])
 


### PR DESCRIPTION
The value for the field is either read from the 'format' field or the
mimetype field, whichever is not falsey.
Previously we set the fileType attribute as well, but this is a
non-existing schema.org attribute.

see #75 