### PR TITLE
Remove _get_user_name and use the logic from ckanext_harvest instead

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -26,8 +26,6 @@ class DCATHarvester(HarvesterBase):
 
     force_import = False
 
-    _user_name = None
-
     def _get_content_and_type(self, url, harvest_job, page=1,
                               content_type=None):
         '''
@@ -118,17 +116,6 @@ class DCATHarvester(HarvesterBase):
                 ' out.' % url
             self._save_gather_error(msg, harvest_job)
             return None, None
-
-    def _get_user_name(self):
-        if self._user_name:
-            return self._user_name
-
-        user = p.toolkit.get_action('get_site_user')(
-            {'ignore_auth': True, 'defer_commit': True},
-            {})
-        self._user_name = user['name']
-
-        return self._user_name
 
     def _get_object_extra(self, harvest_object, key):
         '''


### PR DESCRIPTION
The function _get_user_name already exists in the base ckanext-harvest (https://github.com/ckan/ckanext-harvest/blob/9efb9f4ee579dbeef1bcb32fa52d5e33f9145d9e/ckanext/harvest/harvesters/base.py#L167) with an extended implementation, e.g. allows to customize the harvest user and uses the default fallback user.
Maybe there was a need in the past for this function in ckanext-dcat, but actually I see no longer the need to overwrite the function _get_user_name and restrict the functionality of the super function.