### PR TITLE
Import xrange rename from six for Py3 friendliness

### DIFF
--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -349,7 +349,7 @@ class RDFSerializer(RDFProcessor):
         source_uri = _get_from_extra('source_catalog_homepage')
         if not source_uri:
             return
-        
+
         g = self.g
         catalog_ref = URIRef(source_uri)
 
@@ -396,9 +396,9 @@ class RDFSerializer(RDFProcessor):
                     elif val is None:
                         continue
                     g.add((agent, predicate, _type(val)))
-        
+
         return catalog_ref
-        
+
 
 if __name__ == '__main__':
 

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -2,6 +2,7 @@
 import time
 import nose
 
+from six.moves import xrange
 
 from ckan import plugins as p
 from ckan.lib.helpers import url_for

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -6,6 +6,8 @@ import nose
 import httpretty
 from mock import patch
 
+from six.moves import xrange
+
 import ckan.plugins as p
 import ckantoolkit.tests.helpers as h
 

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -1,6 +1,8 @@
 import nose
 import mock
 
+from six.moves import xrange
+
 from ckantoolkit import config
 
 from ckan.plugins import toolkit


### PR DESCRIPTION
This doesn't include six in the requirements as they should be available
from CKAN.