### PR TITLE
Allow CI failures on master (unreleased CKAN version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ before_install:
     - pip install codecov
 after_success:
     - codecov
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ env:
     - CKANVERSION=2.6
     - CKANVERSION=2.7
     - CKANVERSION=2.8
-
+allow_failures:
+    - env: CKANVERSION=master
 install:
     - bash bin/travis-build.bash
 services:


### PR DESCRIPTION
This will allow a failure in the CI (so it appears as a pass for all other CKAN versions) on the master, given it's a ongonig working branch for CKAN core there will be times it breaks but this should not fail the build for known supported and released version of CKAN used with this module.

(Hopefully I've remembered my Travis config correctly! :D) 