### PR TITLE
Add RDF.type to resource checksum

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -43,6 +43,7 @@ namespaces = {
     'locn': LOCN,
     'gsp': GSP,
     'owl': OWL,
+    'spdx': SPDX,
 }
 
 
@@ -1116,6 +1117,7 @@ class EuropeanDCATAPProfile(RDFProfile):
             # Checksum
             if resource_dict.get('hash'):
                 checksum = BNode()
+                g.add((checksum, RDF.type, SPDX.Checksum))
                 g.add((checksum, SPDX.checksumValue,
                        Literal(resource_dict['hash'],
                                datatype=XSD.hexBinary)))

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
@@ -559,6 +559,7 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         # Checksum
         checksum = self._triple(g, distribution, SPDX.checksum, None)[2]
         assert checksum
+        assert self._triple(g, checksum, RDF.type, SPDX.Checksum)
         assert self._triple(g, checksum, SPDX.checksumValue, resource['hash'], data_type='http://www.w3.org/2001/XMLSchema#hexBinary')
         assert self._triple(g, checksum, SPDX.algorithm, URIRef(resource['hash_algorithm']))
 
@@ -936,6 +937,7 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
 
         checksum = self._triple(g, distribution, SPDX.checksum, None)[2]
         assert checksum
+        assert self._triple(g, checksum, RDF.type, SPDX.Checksum)
         assert self._triple(g, checksum, SPDX.checksumValue, resource['hash'], data_type='http://www.w3.org/2001/XMLSchema#hexBinary')
         assert self._triple(g, checksum, SPDX.algorithm, resource['hash_algorithm'])
 


### PR DESCRIPTION
The RDF.type was missing for resource checksums.