### PR TITLE
Make _object_value_int more robust by accepting decimals as well

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -128,7 +128,7 @@ class RDFProfile(object):
         object_value = self._object_value(subject, predicate)
         if object_value:
             try:
-                return int(object_value)
+                return int(float(object_value))
             except ValueError:
                 pass
         return None

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -94,6 +94,20 @@ class TestBaseRDFProfile(object):
         assert isinstance(value, int)
         eq_(value, 23)
 
+    def test_object_int_decimal(self):
+
+        p = RDFProfile(_default_graph())
+
+        p.g.add((URIRef('http://example.org/datasets/1'),
+                 TEST.some_number,
+                 Literal('23.0')))
+
+        value = p._object_value_int(URIRef('http://example.org/datasets/1'),
+                                    TEST.some_number)
+
+        assert isinstance(value, int)
+        eq_(value, 23)
+
     def test_object_int_not_found(self):
 
         p = RDFProfile(_default_graph())


### PR DESCRIPTION
Parsing values containing dots led to value loss in `_object_value_int`.

This also parses floating point values to integers, which makes parsing more robust.