### PR TITLE
Improve mailto handling and add generic value modifier to _add_triple_from_dict

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -475,8 +475,8 @@ class RDFProfile(object):
                               fallbacks=None,
                               list_value=False,
                               date_value=False,
-                              value_modifier=None,
-                              _type=Literal):
+                              _type=Literal,
+                              value_modifier=None):
         '''
         Adds a new triple to the graph with the provided parameters
 

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -471,15 +471,19 @@ class RDFProfile(object):
                               fallbacks=None,
                               list_value=False,
                               date_value=False,
+                              value_modifier=None,
                               _type=Literal):
         '''
         Adds a new triple to the graph with the provided parameters
 
         The subject and predicate of the triple are passed as the relevant
-        RDFLib objects (URIRef or BNode). The object is always a literal value,
-        which is extracted from the dict using the provided key (see
-        `_get_dict_value`). If the value for the key is not found, then
+        RDFLib objects (URIRef or BNode). As default, the object is a
+        literal value, which is extracted from the dict using the provided key
+        (see `_get_dict_value`). If the value for the key is not found, then
         additional fallback keys are checked.
+        Using `value_modifier`, a function taking the extracted value and
+        returning a modified value can be passed.
+        If a value was found, the modifier is applied before adding the value.
 
         If `list_value` or `date_value` are True, then the value is treated as
         a list or a date respectively (see `_add_list_triple` and
@@ -491,6 +495,10 @@ class RDFProfile(object):
                 value = self._get_dict_value(_dict, fallback)
                 if value:
                     break
+
+        # if a modifying function was given, apply it to the value
+        if value and callable(value_modifier):
+            value = value_modifier(value)
 
         if value and list_value:
             self._add_list_triple(subject, predicate, value, _type)

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -300,4 +300,5 @@ class TestBaseRDFProfile(object):
         contact = p._contact_details(URIRef('http://example.org'), ADMS.contactPoint)
 
         eq_(contact['name'], 'Point of Contact')
-        eq_(contact['email'], 'mailto:contact@some.org')
+        # mailto gets removed for storage and is added again on output
+        eq_(contact['email'], 'contact@some.org')

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -91,7 +91,8 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         eq_(_get_extra_value('publisher_url'), 'http://some.org')
         eq_(_get_extra_value('publisher_type'), 'http://purl.org/adms/publishertype/NonProfitOrganisation')
         eq_(_get_extra_value('contact_name'), 'Point of Contact')
-        eq_(_get_extra_value('contact_email'), 'mailto:contact@some.org')
+        # mailto gets removed for storage and is added again on output
+        eq_(_get_extra_value('contact_email'), 'contact@some.org')
         eq_(_get_extra_value('access_rights'), 'public')
         eq_(_get_extra_value('provenance'), 'Some statement about provenance')
         eq_(_get_extra_value('dcat_type'), 'test-type')
@@ -555,7 +556,8 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         eq_(dataset['title'], 'U.S. Widget Manufacturing Statistics')
 
         eq_(extras['contact_name'], 'Jane Doe')
-        eq_(extras['contact_email'], 'mailto:jane.doe@agency.gov')
+        # mailto gets removed for storage and is added again on output
+        eq_(extras['contact_email'], 'jane.doe@agency.gov')
         eq_(extras['publisher_name'], 'Widget Services')
         eq_(extras['publisher_email'], 'widget.services@agency.gov')
 

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
@@ -219,7 +219,7 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         assert contact_details
         eq_(unicode(contact_details), extras['contact_uri'])
         assert self._triple(g, contact_details, VCARD.fn, extras['contact_name'])
-        assert self._triple(g, contact_details, VCARD.hasEmail, extras['contact_email'])
+        assert self._triple(g, contact_details, VCARD.hasEmail, URIRef('mailto:' + extras['contact_email']))
 
     def test_contact_details_maintainer(self):
         dataset = {
@@ -240,7 +240,7 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         assert contact_details
         assert_true(isinstance(contact_details, BNode))
         assert self._triple(g, contact_details, VCARD.fn, dataset['maintainer'])
-        assert self._triple(g, contact_details, VCARD.hasEmail, dataset['maintainer_email'])
+        assert self._triple(g, contact_details, VCARD.hasEmail, URIRef('mailto:' + dataset['maintainer_email']))
 
     def test_contact_details_author(self):
         dataset = {
@@ -259,7 +259,27 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         assert contact_details
         assert_true(isinstance(contact_details, BNode))
         assert self._triple(g, contact_details, VCARD.fn, dataset['author'])
-        assert self._triple(g, contact_details, VCARD.hasEmail, dataset['author_email'])
+        assert self._triple(g, contact_details, VCARD.hasEmail, URIRef('mailto:' + dataset['author_email']))
+
+    def test_contact_details_no_duplicate_mailto(self):
+        # tests that mailto: isn't added again if it is stored in the dataset
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'author': 'Example Author',
+            'author_email': 'mailto:ped@example.com',
+        }
+
+        s = RDFSerializer()
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        contact_details = self._triple(g, dataset_ref, DCAT.contactPoint, None)[2]
+        assert contact_details
+        assert_true(isinstance(contact_details, BNode))
+        assert self._triple(g, contact_details, VCARD.fn, dataset['author'])
+        assert self._triple(g, contact_details, VCARD.hasEmail, URIRef(dataset['author_email']))
 
     def test_publisher_extras(self):
         dataset = {


### PR DESCRIPTION
The generic modifier allows to provide a function which updates the value before it is added to the graph from the dict.

Also, this improves handling of mail addresses:

* Use URIRef instead of Literals for email addresses
* ensure that `mailto:` is prepended to the address