### PR TITLE
Encode URIRef and remove white-spaces

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1,6 +1,8 @@
 import datetime
 import json
 
+from urllib import quote
+
 from dateutil.parser import parse as parse_date
 
 from ckantoolkit import config
@@ -44,6 +46,34 @@ namespaces = {
     'gsp': GSP,
     'owl': OWL,
 }
+
+class CleanedURIRef(object):
+    '''Performs either some basic URL encoding (for http[s]) or whitespace removal on value
+    before creating an URIRef object.
+
+    This is a factory for URIRef objects, which allows usage as type in graph.add()
+    without affecting the resulting node types. That is,
+    g.add(..., URIRef) and g.add(..., CleanedURIRef) will result in the exact same node type.
+    '''
+    @staticmethod
+    def _careful_quote(value):
+        # only encode this limited subset of characters to avoid more complex URL parsing
+        # (e.g. valid ? in query string vs. ? as value).
+        # can be applied multiple times, as encoded %xy is left untouched. Therefore, no
+        # unquote is necessary beforehand.
+        quotechars = ' !"$\'()*,;<>[]{|}'
+        for c in quotechars:
+            value = value.replace(c, quote(c))
+        return value
+
+    def __new__(cls, value):
+        if isinstance(value, basestring):
+            if value.startswith('http'):
+                value = CleanedURIRef._careful_quote(value)
+            else:
+                value = value.replace(' ', '')
+
+        return URIRef(value)
 
 
 class RDFProfile(object):
@@ -498,6 +528,9 @@ class RDFProfile(object):
             self._add_date_triple(subject, predicate, value, _type)
         elif value:
             # Normal text value
+            # ensure URIRef items are preprocessed (space removal/url encoding)
+            if _type == URIRef:
+                _type = CleanedURIRef
             self.g.add((subject, predicate, _type(value)))
 
     def _add_list_triple(self, subject, predicate, value, _type=Literal):
@@ -527,6 +560,9 @@ class RDFProfile(object):
                     items = [value]
 
         for item in items:
+            # ensure URIRef items are preprocessed (space removal/url encoding)
+            if _type == URIRef:
+                _type = CleanedURIRef
             self.g.add((subject, predicate, _type(item)))
 
     def _add_date_triple(self, subject, predicate, value, _type=Literal):
@@ -950,7 +986,7 @@ class EuropeanDCATAPProfile(RDFProfile):
 
             contact_uri = self._get_dataset_value(dataset_dict, 'contact_uri')
             if contact_uri:
-                contact_details = URIRef(contact_uri)
+                contact_details = CleanedURIRef(contact_uri)
             else:
                 contact_details = BNode()
 
@@ -974,7 +1010,7 @@ class EuropeanDCATAPProfile(RDFProfile):
 
             publisher_uri = publisher_uri_from_dataset_dict(dataset_dict)
             if publisher_uri:
-                publisher_details = URIRef(publisher_uri)
+                publisher_details = CleanedURIRef(publisher_uri)
             else:
                 # No organization nor publisher_uri
                 publisher_details = BNode()
@@ -1019,7 +1055,7 @@ class EuropeanDCATAPProfile(RDFProfile):
 
         if spatial_uri or spatial_text or spatial_geom:
             if spatial_uri:
-                spatial_ref = URIRef(spatial_uri)
+                spatial_ref = CleanedURIRef(spatial_uri)
             else:
                 spatial_ref = BNode()
 
@@ -1047,7 +1083,7 @@ class EuropeanDCATAPProfile(RDFProfile):
         # Resources
         for resource_dict in dataset_dict.get('resources', []):
 
-            distribution = URIRef(resource_uri(resource_dict))
+            distribution = CleanedURIRef(resource_uri(resource_dict))
 
             g.add((dataset_ref, DCAT.distribution, distribution))
 
@@ -1094,7 +1130,7 @@ class EuropeanDCATAPProfile(RDFProfile):
             # Use url as fallback for access_url if access_url is not set and download_url is not equal
             if url and not access_url:
                 if (not download_url) or (download_url and url != download_url):
-                  g.add((distribution, DCAT.accessURL, URIRef(url)))
+                  self._add_triple_from_dict(resource_dict, distribution, DCAT.accessURL, 'url', _type=URIRef)
 
             # Dates
             items = [
@@ -1123,7 +1159,7 @@ class EuropeanDCATAPProfile(RDFProfile):
                 if resource_dict.get('hash_algorithm'):
                     if resource_dict['hash_algorithm'].startswith('http'):
                         g.add((checksum, SPDX.algorithm,
-                               URIRef(resource_dict['hash_algorithm'])))
+                               CleanedURIRef(resource_dict['hash_algorithm'])))
                     else:
                         g.add((checksum, SPDX.algorithm,
                                Literal(resource_dict['hash_algorithm'])))

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -48,8 +48,7 @@ namespaces = {
 }
 
 class CleanedURIRef(object):
-    '''Performs either some basic URL encoding (for http[s]) or whitespace removal on value
-    before creating an URIRef object.
+    '''Performs either some basic URL encoding on value before creating an URIRef object.
 
     This is a factory for URIRef objects, which allows usage as type in graph.add()
     without affecting the resulting node types. That is,
@@ -68,11 +67,7 @@ class CleanedURIRef(object):
 
     def __new__(cls, value):
         if isinstance(value, basestring):
-            if value.startswith('http'):
-                value = CleanedURIRef._careful_quote(value)
-            else:
-                value = value.replace(' ', '')
-
+            value = CleanedURIRef._careful_quote(value.strip())
         return URIRef(value)
 
 

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -23,6 +23,13 @@ class TestURIRefPreprocessing(object):
         
         for prefix in ['http', 'https']:
             eq_(CleanedURIRef(prefix + testUriPart), URIRef(prefix + testUriPart))
+            # leading and trailing whitespace should be removed
+            eq_(CleanedURIRef(' ' + prefix + testUriPart + ' '), URIRef(prefix + testUriPart))
+
+        testNonHttpUri = "mailto:someone@example.com"
+        eq_(CleanedURIRef(testNonHttpUri), URIRef(testNonHttpUri))
+        # leading and trailing whitespace should be removed again
+        eq_(CleanedURIRef(' ' + testNonHttpUri + ' '), URIRef(testNonHttpUri))
 
     def test_with_invalid_items(self):
         testUriPart = "://www.w3.org/ns/!dcat #"
@@ -33,13 +40,13 @@ class TestURIRefPreprocessing(object):
             # applying on escaped data should have no effect
             eq_(CleanedURIRef(prefix + expectedUriPart), URIRef(prefix + expectedUriPart))
 
-    def test_non_http_only_spaces(self):
-        testUri = "mailto:with space@example.com "
-        expectedUri = "mailto:withspace@example.com"
+        # leading and trailing space should not be escaped
+        testNonHttpUri = " mailto:with space!@example.com "
+        expectedNonHttpUri = "mailto:with%20space%21@example.com"
 
-        eq_(CleanedURIRef(testUri), URIRef(expectedUri))
+        eq_(CleanedURIRef(testNonHttpUri), URIRef(expectedNonHttpUri))
         # applying on escaped data should have no effect
-        eq_(CleanedURIRef(expectedUri), URIRef(expectedUri))
+        eq_(CleanedURIRef(expectedNonHttpUri), URIRef(expectedNonHttpUri))
 
 
 class TestBaseRDFProfile(object):

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -3,7 +3,7 @@ import nose
 from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import Namespace
 
-from ckanext.dcat.profiles import RDFProfile
+from ckanext.dcat.profiles import RDFProfile, CleanedURIRef
 
 from ckanext.dcat.tests.test_base_parser import _default_graph
 
@@ -14,6 +14,32 @@ DCT = Namespace("http://purl.org/dc/terms/")
 TEST = Namespace("http://test.org/")
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 ADMS = Namespace("http://www.w3.org/ns/adms#")
+
+
+class TestURIRefPreprocessing(object):
+
+    def test_with_valid_items(self):
+        testUriPart = "://www.w3.org/ns/dcat#"
+        
+        for prefix in ['http', 'https']:
+            eq_(CleanedURIRef(prefix + testUriPart), URIRef(prefix + testUriPart))
+
+    def test_with_invalid_items(self):
+        testUriPart = "://www.w3.org/ns/!dcat #"
+        expectedUriPart = "://www.w3.org/ns/%21dcat%20#"
+        
+        for prefix in ['http', 'https']:
+            eq_(CleanedURIRef(prefix + testUriPart), URIRef(prefix + expectedUriPart))
+            # applying on escaped data should have no effect
+            eq_(CleanedURIRef(prefix + expectedUriPart), URIRef(prefix + expectedUriPart))
+
+    def test_non_http_only_spaces(self):
+        testUri = "mailto:with space@example.com "
+        expectedUri = "mailto:withspace@example.com"
+
+        eq_(CleanedURIRef(testUri), URIRef(expectedUri))
+        # applying on escaped data should have no effect
+        eq_(CleanedURIRef(expectedUri), URIRef(expectedUri))
 
 
 class TestBaseRDFProfile(object):


### PR DESCRIPTION
The pull request adds an careful URIRef quoting for URIs with http(s) and white-space removal for URIs without http(s), e.g. mailto.

It mainly solves an internal server error when serializing the graph. If there are some datasets in the database with URIs containing white-spaces, it is not possible to serialize the graph which returns into an internal server error.
Furthermore it solves the problem with incorrect encoded URIs which can result in a problem in a remote system when it is importing the graph.
