### PR TITLE
Add missing schema.org fields

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1251,6 +1251,7 @@ class SchemaOrgProfile(RDFProfile):
             ('version', SCHEMA.version, ['dcat_version'], Literal),
             ('issued', SCHEMA.datePublished, ['metadata_created'], Literal),
             ('modified', SCHEMA.dateModified, ['metadata_modified'], Literal),
+            ('license', SCHEMA.license, ['license_url', 'license_title'], Literal),
         ]
         self._add_triples_from_dict(dataset_dict, dataset_ref, items)
 

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1258,6 +1258,13 @@ class SchemaOrgProfile(RDFProfile):
 
         self._add_date_triples_from_dict(dataset_dict, dataset_ref, items)
 
+        # Dataset URL
+        dataset_url = url_for(controller='package',
+                              action='read',
+                              id=dataset_dict['name'],
+                              qualified=True)
+        self.g.add((dataset_ref, SCHEMA.url, Literal(dataset_url)))
+
     def _groups_graph(self, dataset_ref, dataset_dict):
         for group in dataset_dict.get('groups', []):
             group_url = url_for(controller='group',

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1201,6 +1201,18 @@ class SchemaOrgProfile(RDFProfile):
 
         # Resources
         self._resources_graph(dataset_ref, dataset_dict)
+        
+        # Additional fields
+        self.additional_fields(dataset_ref, dataset_dict)
+
+    def additional_fields(self, dataset_ref, dataset_dict):
+        '''
+        Adds any additional fields.
+
+        For a custom schema you should extend this class and
+        implement this method.
+        '''
+        pass
 
     def _add_date_triple(self, subject, predicate, value, _type=Literal):
         '''

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1185,6 +1185,9 @@ class SchemaOrgProfile(RDFProfile):
         # Basic fields
         self._basic_fields_graph(dataset_ref, dataset_dict)
 
+        # Catalog
+        self._catalog_graph(dataset_ref, dataset_dict)
+
         # Groups
         self._groups_graph(dataset_ref, dataset_dict)
 
@@ -1264,6 +1267,14 @@ class SchemaOrgProfile(RDFProfile):
                               id=dataset_dict['name'],
                               qualified=True)
         self.g.add((dataset_ref, SCHEMA.url, Literal(dataset_url)))
+
+    def _catalog_graph(self, dataset_ref, dataset_dict):
+        data_catalog = BNode()
+        self.g.add((dataset_ref, SCHEMA.includedInDataCatalog, data_catalog))
+        self.g.add((data_catalog, RDF.type, SCHEMA.DataCatalog))
+        self.g.add((data_catalog, SCHEMA.name, Literal(config.get('ckan.site_title'))))
+        self.g.add((data_catalog, SCHEMA.description, Literal(config.get('ckan.site_description'))))
+        self.g.add((data_catalog, SCHEMA.url, Literal(config.get('ckan.site_url'))))
 
     def _groups_graph(self, dataset_ref, dataset_dict):
         for group in dataset_dict.get('groups', []):

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1262,8 +1262,7 @@ class SchemaOrgProfile(RDFProfile):
         self._add_date_triples_from_dict(dataset_dict, dataset_ref, items)
 
         # Dataset URL
-        dataset_url = url_for(controller='package',
-                              action='read',
+        dataset_url = url_for('dataset_read',
                               id=dataset_dict['name'],
                               qualified=True)
         self.g.add((dataset_ref, SCHEMA.url, Literal(dataset_url)))

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -14,6 +14,7 @@ from geomet import wkt, InvalidGeoJSONException
 from ckan.model.license import LicenseRegister
 from ckan.plugins import toolkit
 from ckan.lib.munge import munge_tag
+from ckan.lib.helpers import url_for
 
 from ckanext.dcat.utils import resource_uri, publisher_uri_from_dataset_dict, DCAT_EXPOSE_SUBCATALOGS, DCAT_CLEAN_TAGS
 
@@ -1184,6 +1185,9 @@ class SchemaOrgProfile(RDFProfile):
         # Basic fields
         self._basic_fields_graph(dataset_ref, dataset_dict)
 
+        # Groups
+        self._groups_graph(dataset_ref, dataset_dict)
+
         # Tags
         self._tags_graph(dataset_ref, dataset_dict)
 
@@ -1254,6 +1258,14 @@ class SchemaOrgProfile(RDFProfile):
 
         self._add_date_triples_from_dict(dataset_dict, dataset_ref, items)
 
+    def _groups_graph(self, dataset_ref, dataset_dict):
+        for group in dataset_dict.get('groups', []):
+            group_url = url_for(controller='group',
+                                action='read',
+                                id=group.get('id'),
+                                qualified=True)
+            self.g.add((dataset_ref, SCHEMA.genre, Literal(group_url)))
+
     def _tags_graph(self, dataset_ref, dataset_dict):
         for tag in dataset_dict.get('tags', []):
             self.g.add((dataset_ref, SCHEMA.keywords, Literal(tag['name'])))
@@ -1261,7 +1273,6 @@ class SchemaOrgProfile(RDFProfile):
     def _list_fields_graph(self, dataset_ref, dataset_dict):
         items = [
             ('language', SCHEMA.inLanguage, None, Literal),
-            ('theme', SCHEMA.about, None, URIRef),
         ]
         self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
 

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -68,6 +68,9 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, SCHEMA.description, dataset['notes'])
         assert self._triple(g, dataset_ref, SCHEMA.version, dataset['version'])
         assert self._triple(g, dataset_ref, SCHEMA.identifier, extras['identifier'])
+        url = self._triple(g, dataset_ref, SCHEMA.url, None)
+        assert url
+        eq_(url, 'http://test.ckan.net/dataset/%s' % dataset['name'])
 
         # Dates
         assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'])
@@ -81,7 +84,6 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         # List
         for item in [
             ('language', SCHEMA.inLanguage, Literal),
-            ('theme', SCHEMA.about, URIRef),
         ]:
             values = json.loads(extras[item[0]])
             eq_(len([t for t in g.triples((dataset_ref, item[1], None))]), len(values))
@@ -148,6 +150,52 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert publisher
         assert self._triple(g, publisher, RDF.type, SCHEMA.Organization)
         assert self._triple(g, publisher, SCHEMA.name, dataset['organization']['title'])
+
+    def test_groups(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'groups': [
+                {
+                    'id': 'geography',
+                    'name': 'geography',
+                    'display_name': 'Geography',
+                },
+                {
+                    'id': 'statistics',
+                    'name': 'statistics',
+                    'display_name': 'Statistics',
+                },
+            ]
+        }
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        genres = self._triples(g, dataset_ref, SCHEMA.genre, None)
+        assert len(genres) == 2, 'There are not exactly 2 groups'
+        assert self._triple(g, dataset_ref, SCHEMA.genre, 'http://test.ckan.net/group/statistics')
+
+    @helpers.change_config('ckan.site_url', 'http://ckan.example.org')
+    @helpers.change_config('ckan.site_description', 'CKAN Portal')
+    @helpers.change_config('ckan.site_title', 'ckan.example.org')
+    def test_catalog(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+        }
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+        data_catalog = self._triple(g, dataset_ref, SCHEMA.includedInDataCatalog, None)[2]
+        assert data_catalog
+        assert self._triple(g, data_catalog, RDF.type, SCHEMA.DataCatalog)
+        assert self._triple(g, data_catalog, SCHEMA.url, 'http://ckan.example.org')
+        assert self._triple(g, data_catalog, SCHEMA.name, 'ckan.example.org')
+        assert self._triple(g, data_catalog, SCHEMA.description, 'CKAN Portal')
 
     def test_temporal_start_and_end(self):
         dataset = {

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -68,9 +68,9 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, SCHEMA.description, dataset['notes'])
         assert self._triple(g, dataset_ref, SCHEMA.version, dataset['version'])
         assert self._triple(g, dataset_ref, SCHEMA.identifier, extras['identifier'])
-        url = self._triple(g, dataset_ref, SCHEMA.url, None)
+        url = self._triple(g, dataset_ref, SCHEMA.url, None)[2]
         assert url
-        eq_(url, 'http://test.ckan.net/dataset/%s' % dataset['name'])
+        eq_(url, Literal('http://test.ckan.net/dataset/%s' % dataset['name']))
 
         # Dates
         assert self._triple(g, dataset_ref, SCHEMA.datePublished, dataset['metadata_created'])

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -33,6 +33,8 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
             'version': '1.0b',
             'metadata_created': '2015-06-26T15:21:09.034694',
             'metadata_modified': '2015-06-26T15:21:09.075774',
+            'license_title': 'CC-BY 3.0',
+            'license_url': 'http://creativecommons.org/licenses/by/3.0/',
             'tags': [{'name': 'Tag 1'}, {'name': 'Tag 2'}],
             'extras': [
                 {'key': 'alternate_identifier', 'value': '[\"xyz\", \"abc\"]'},
@@ -67,6 +69,7 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, SCHEMA.name, dataset['title'])
         assert self._triple(g, dataset_ref, SCHEMA.description, dataset['notes'])
         assert self._triple(g, dataset_ref, SCHEMA.version, dataset['version'])
+        assert self._triple(g, dataset_ref, SCHEMA.license, dataset['license_url'])
         assert self._triple(g, dataset_ref, SCHEMA.identifier, extras['identifier'])
         url = self._triple(g, dataset_ref, SCHEMA.url, None)[2]
         assert url


### PR DESCRIPTION
This PR adds the following fields:

- url of the dataset (SCHEMA.url)
- group URLs to SCHEMA.genre
- license to SCHEMA.license
- information about the catalog as a SCHEMA.DataCatalog

Additionally a new method `additional_fields` is added, which makes it easy in a subclass to add their own fields without having to override one of the "internal methods" of the provided SchemaOrgProfile class