### PR TITLE
Prefer default language values for some Literal nodes

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -156,7 +156,7 @@ class RDFProfile(object):
             return _object
         return None
 
-    def _object_value(self, subject, predicate, use_default_lang=False):
+    def _object_value(self, subject, predicate):
         '''
         Given a subject and a predicate, returns the value of the object
 
@@ -167,7 +167,7 @@ class RDFProfile(object):
         default_lang = config.get('ckan.locale_default', 'en')
         fallback = ''
         for o in self.g.objects(subject, predicate):
-            if use_default_lang and isinstance(o, Literal):
+            if isinstance(o, Literal):
                 if o.language and o.language == default_lang:
                     return unicode(o)
                 # Use first object as fallback if no object with the default language is available
@@ -287,7 +287,7 @@ class RDFProfile(object):
             publisher['uri'] = (unicode(agent) if isinstance(agent,
                                 rdflib.term.URIRef) else '')
 
-            publisher['name'] = self._object_value(agent, FOAF.name, use_default_lang=True)
+            publisher['name'] = self._object_value(agent, FOAF.name)
 
             publisher['email'] = self._object_value(agent, FOAF.mbox)
 
@@ -314,7 +314,7 @@ class RDFProfile(object):
             contact['uri'] = (unicode(agent) if isinstance(agent,
                               rdflib.term.URIRef) else '')
 
-            contact['name'] = self._object_value(agent, VCARD.fn, use_default_lang=True)
+            contact['name'] = self._object_value(agent, VCARD.fn)
 
             contact['email'] = self._without_mailto(
                 self._object_value(agent, VCARD.hasEmail)
@@ -778,19 +778,12 @@ class EuropeanDCATAPProfile(RDFProfile):
 
         # Basic fields
         for key, predicate in (
+                ('title', DCT.title),
+                ('notes', DCT.description),
                 ('url', DCAT.landingPage),
                 ('version', OWL.versionInfo),
                 ):
             value = self._object_value(dataset_ref, predicate)
-            if value:
-                dataset_dict[key] = value
-
-        # Multilingual basic fields
-        for key, predicate in (
-                ('title', DCT.title),
-                ('notes', DCT.description),
-                ):
-            value = self._object_value(dataset_ref, predicate, use_default_lang=True)
             if value:
                 dataset_dict[key] = value
 
@@ -911,6 +904,8 @@ class EuropeanDCATAPProfile(RDFProfile):
 
             #  Simple values
             for key, predicate in (
+                    ('name', DCT.title),
+                    ('description', DCT.description),
                     ('access_url', DCAT.accessURL),
                     ('download_url', DCAT.downloadURL),
                     ('issued', DCT.issued),
@@ -927,15 +922,6 @@ class EuropeanDCATAPProfile(RDFProfile):
                                                        DCAT.downloadURL) or
                                     self._object_value(distribution,
                                                        DCAT.accessURL))
-            # Multilingual simple values
-            for key, predicate in (
-                    ('name', DCT.title),
-                    ('description', DCT.description),
-                    ):
-                value = self._object_value(distribution, predicate, use_default_lang=True)
-                if value:
-                    resource_dict[key] = value
-
             #  Lists
             for key, predicate in (
                     ('language', DCT.language),

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -156,7 +156,7 @@ class RDFProfile(object):
             return _object
         return None
 
-    def _object_value(self, subject, predicate):
+    def _object_value(self, subject, predicate, use_default_lang=False):
         '''
         Given a subject and a predicate, returns the value of the object
 
@@ -164,9 +164,18 @@ class RDFProfile(object):
 
         If found, the unicode representation is returned, else an empty string
         '''
+        default_lang = config.get('ckan.locale_default', 'en')
+        fallback = ''
         for o in self.g.objects(subject, predicate):
-            return unicode(o)
-        return ''
+            if use_default_lang and isinstance(o, Literal):
+                if o.language and o.language == default_lang:
+                    return unicode(o)
+                # Use first object as fallback if no object with the default language is available
+                elif fallback == '':
+                    fallback = unicode(o)
+            else:
+                return unicode(o)
+        return fallback
 
     def _object_value_int(self, subject, predicate):
         '''

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -287,7 +287,7 @@ class RDFProfile(object):
             publisher['uri'] = (unicode(agent) if isinstance(agent,
                                 rdflib.term.URIRef) else '')
 
-            publisher['name'] = self._object_value(agent, FOAF.name)
+            publisher['name'] = self._object_value(agent, FOAF.name, use_default_lang=True)
 
             publisher['email'] = self._object_value(agent, FOAF.mbox)
 
@@ -314,7 +314,7 @@ class RDFProfile(object):
             contact['uri'] = (unicode(agent) if isinstance(agent,
                               rdflib.term.URIRef) else '')
 
-            contact['name'] = self._object_value(agent, VCARD.fn)
+            contact['name'] = self._object_value(agent, VCARD.fn, use_default_lang=True)
 
             contact['email'] = self._without_mailto(
                 self._object_value(agent, VCARD.hasEmail)
@@ -778,12 +778,19 @@ class EuropeanDCATAPProfile(RDFProfile):
 
         # Basic fields
         for key, predicate in (
-                ('title', DCT.title),
-                ('notes', DCT.description),
                 ('url', DCAT.landingPage),
                 ('version', OWL.versionInfo),
                 ):
             value = self._object_value(dataset_ref, predicate)
+            if value:
+                dataset_dict[key] = value
+
+        # Multilingual basic fields
+        for key, predicate in (
+                ('title', DCT.title),
+                ('notes', DCT.description),
+                ):
+            value = self._object_value(dataset_ref, predicate, use_default_lang=True)
             if value:
                 dataset_dict[key] = value
 
@@ -904,8 +911,6 @@ class EuropeanDCATAPProfile(RDFProfile):
 
             #  Simple values
             for key, predicate in (
-                    ('name', DCT.title),
-                    ('description', DCT.description),
                     ('access_url', DCAT.accessURL),
                     ('download_url', DCAT.downloadURL),
                     ('issued', DCT.issued),
@@ -922,6 +927,15 @@ class EuropeanDCATAPProfile(RDFProfile):
                                                        DCAT.downloadURL) or
                                     self._object_value(distribution,
                                                        DCAT.accessURL))
+            # Multilingual simple values
+            for key, predicate in (
+                    ('name', DCT.title),
+                    ('description', DCT.description),
+                    ):
+                value = self._object_value(distribution, predicate, use_default_lang=True)
+                if value:
+                    resource_dict[key] = value
+
             #  Lists
             for key, predicate in (
                     ('language', DCT.language),

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -125,7 +125,7 @@ class TestBaseRDFProfile(object):
                  DCT.title, Literal('Test Dataset 1 (EN)', lang='en')))
 
         value = p._object_value(URIRef('http://example.org/datasets/1'),
-                                DCT.title, use_default_lang=True)
+                                DCT.title)
 
         assert isinstance(value, unicode)
         eq_(value, 'Test Datensatz 1')
@@ -139,7 +139,7 @@ class TestBaseRDFProfile(object):
                  DCT.title, Literal('Test Dataset 1 (EN)', lang='en')))
 
         value = p._object_value(URIRef('http://example.org/datasets/1'),
-                                DCT.title, use_default_lang=True)
+                                DCT.title)
 
         assert isinstance(value, unicode)
         eq_(value, 'Test Dataset 1 (EN)')
@@ -148,7 +148,7 @@ class TestBaseRDFProfile(object):
         p = RDFProfile(_default_graph())
 
         value = p._object_value(URIRef('http://example.org/datasets/1'),
-                                DCT.title, use_default_lang=True)
+                                DCT.title)
 
         assert isinstance(value, unicode)
         eq_(value, 'Test Dataset 1')

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -130,6 +130,21 @@ class TestBaseRDFProfile(object):
         assert isinstance(value, unicode)
         eq_(value, 'Test Datensatz 1')
 
+    @helpers.change_config('ckan.locale_default', 'fr')
+    def test_object_value_default_lang_not_in_graph(self):
+        p = RDFProfile(_default_graph())
+
+        p.g.add((URIRef('http://example.org/datasets/1'),
+                 DCT.title, Literal('Test Datensatz 1', lang='de')))
+
+        value = p._object_value(URIRef('http://example.org/datasets/1'),
+                                DCT.title)
+
+        assert isinstance(value, unicode)
+        # FR is not in graph, so either node may be used
+        assert value.startswith('Test D')
+        assert value.endswith(' 1')
+
     def test_object_value_default_lang_fallback(self):
         p = RDFProfile(_default_graph())
 
@@ -142,6 +157,7 @@ class TestBaseRDFProfile(object):
                                 DCT.title)
 
         assert isinstance(value, unicode)
+        # without config parameter, EN is used as default
         eq_(value, 'Test Dataset 1 (EN)')
 
     def test_object_value_default_lang_missing_lang_param(self):

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -3,6 +3,8 @@ import nose
 from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import Namespace
 
+from ckantoolkit.tests import helpers
+
 from ckanext.dcat.profiles import RDFProfile, CleanedURIRef
 
 from ckanext.dcat.tests.test_base_parser import _default_graph
@@ -112,6 +114,44 @@ class TestBaseRDFProfile(object):
                                 DCT.unknown_property)
 
         eq_(value, '')
+
+    @helpers.change_config('ckan.locale_default', 'de')
+    def test_object_value_default_lang(self):
+        p = RDFProfile(_default_graph())
+
+        p.g.add((URIRef('http://example.org/datasets/1'),
+                 DCT.title, Literal('Test Datensatz 1', lang='de')))
+        p.g.add((URIRef('http://example.org/datasets/1'),
+                 DCT.title, Literal('Test Dataset 1 (EN)', lang='en')))
+
+        value = p._object_value(URIRef('http://example.org/datasets/1'),
+                                DCT.title, use_default_lang=True)
+
+        assert isinstance(value, unicode)
+        eq_(value, 'Test Datensatz 1')
+
+    def test_object_value_default_lang_fallback(self):
+        p = RDFProfile(_default_graph())
+
+        p.g.add((URIRef('http://example.org/datasets/1'),
+                 DCT.title, Literal('Test Datensatz 1', lang='de')))
+        p.g.add((URIRef('http://example.org/datasets/1'),
+                 DCT.title, Literal('Test Dataset 1 (EN)', lang='en')))
+
+        value = p._object_value(URIRef('http://example.org/datasets/1'),
+                                DCT.title, use_default_lang=True)
+
+        assert isinstance(value, unicode)
+        eq_(value, 'Test Dataset 1 (EN)')
+
+    def test_object_value_default_lang_missing_lang_param(self):
+        p = RDFProfile(_default_graph())
+
+        value = p._object_value(URIRef('http://example.org/datasets/1'),
+                                DCT.title, use_default_lang=True)
+
+        assert isinstance(value, unicode)
+        eq_(value, 'Test Dataset 1')
 
     def test_object_int(self):
 

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -14,7 +14,7 @@ from ckantoolkit.tests import helpers, factories
 
 from ckanext.dcat.processors import RDFParser, RDFSerializer
 from ckanext.dcat.profiles import (DCAT, DCT, ADMS, LOCN, SKOS, GSP, RDFS,
-                                   GEOJSON_IMT)
+                                   GEOJSON_IMT, FOAF, VCARD)
 from ckanext.dcat.utils import DCAT_EXPOSE_SUBCATALOGS, DCAT_CLEAN_TAGS
 
 eq_ = nose.tools.eq_
@@ -351,6 +351,86 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
             eq_(resource['mimetype'], u'text/csv')
         else:
             eq_(resource['format'], u'text/csv')
+
+    @staticmethod
+    def _prepare_default_lang_graph():
+        def _add_node_de_en(g, item_ref, predicate, literal_base_value):
+            g.add((item_ref, predicate, Literal(literal_base_value + '(DE)', lang='de')))
+            g.add((item_ref, predicate, Literal(literal_base_value + '(EN)', lang='en')))
+
+        g = Graph()
+
+        dataset1 = URIRef("http://example.org/datasets/1")
+        g.add((dataset1, RDF.type, DCAT.Dataset))
+        _add_node_de_en(g, dataset1, DCT.title, 'Test dataset')
+        _add_node_de_en(g, dataset1, DCT.description, 'some description')
+
+        publisher_node = BNode()
+        g.add((publisher_node, RDF.type, FOAF.Organization))
+        _add_node_de_en(g, publisher_node, FOAF.name, 'a publisher')
+        g.add((dataset1, DCT.publisher, publisher_node))
+
+        contact_node = BNode()
+        g.add((contact_node, RDF.type, VCARD.Organization))
+        _add_node_de_en(g, contact_node, VCARD.fn, 'a contact')
+        g.add((dataset1, DCAT.contactPoint, contact_node))
+
+        distribution1_1 = URIRef("http://example.org/datasets/1/ds/1")
+        _add_node_de_en(g, distribution1_1, DCT.title, 'Test resource')
+        _add_node_de_en(g, distribution1_1, DCT.description, 'some res description')
+
+        g.add((dataset1, DCAT.distribution, distribution1_1))
+
+        return g
+
+    def _assert_lang_graph(self, dataset, expected_lang):
+        extras = self._extras(dataset)
+        resource = dataset['resources'][0]
+        eq_(dataset['title'], u'Test dataset' + expected_lang)
+        eq_(dataset['notes'], u'some description' + expected_lang)
+        eq_(extras['publisher_name'], u'a publisher' + expected_lang)
+        eq_(extras['contact_name'], u'a contact' + expected_lang)
+        eq_(resource['name'], u'Test resource' + expected_lang)
+        eq_(resource['description'], u'some res description' + expected_lang)
+
+    @helpers.change_config('ckan.locale_default', 'en')
+    def test_default_lang_en(self):
+        g = self._prepare_default_lang_graph()
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+        p.g = g
+
+        dataset = [d for d in p.datasets()][0]
+        self._assert_lang_graph(dataset, '(EN)')
+
+    @helpers.change_config('ckan.locale_default', 'de')
+    def test_default_lang_de(self):
+        g = self._prepare_default_lang_graph()
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+        p.g = g
+
+        dataset = [d for d in p.datasets()][0]
+        self._assert_lang_graph(dataset, '(DE)')
+
+    @helpers.change_config('ckan.locale_default', 'fr')
+    def test_default_lang_not_in_graph(self):
+        g = self._prepare_default_lang_graph()
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+        p.g = g
+
+        dataset = [d for d in p.datasets()][0]
+        extras = self._extras(dataset)
+        resource = dataset['resources'][0]
+
+        # default lang is not present in graph, so only check for correct base values
+        assert_true(u'Test dataset' in dataset['title'])
+        assert_true(u'some description' in dataset['notes'])
+        assert_true(u'a publisher' in extras['publisher_name'])
+        assert_true(u'a contact' in extras['contact_name'])
+        assert_true(u'Test resource' in resource['name'])
+        assert_true(u'some res description' in resource['description'])
 
     @helpers.change_config('ckanext.dcat.normalize_ckan_format', False)
     def test_distribution_format_imt_only_normalize_false(self):


### PR DESCRIPTION
If a graph contains multiple languages for a node, a random node is currently used when parsing.

This introduces the option to prefer the configured default language for some nodes:

* dct:title (dataset and distribution)
* dct:description (dataset and distribution)
* foaf:name in dct:publisher
* vcard:fn in dcat:contactPoint

The changes are related to #51 and #124.