### PR TITLE
Handle import stage errors

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from hashlib import sha1
+import traceback
 import uuid
 
 from ckan import model
@@ -252,41 +253,45 @@ class DCATJSONHarvester(DCATHarvester):
             'ignore_auth': True,
         }
 
-        if status == 'new':
+        try:
+            if status == 'new':
+                package_schema = logic.schema.default_create_package_schema()
+                context['schema'] = package_schema
 
-            package_schema = logic.schema.default_create_package_schema()
-            context['schema'] = package_schema
+                # We need to explicitly provide a package ID
+                package_dict['id'] = unicode(uuid.uuid4())
+                package_schema['id'] = [unicode]
 
-            # We need to explicitly provide a package ID
-            package_dict['id'] = unicode(uuid.uuid4())
-            package_schema['id'] = [unicode]
+                # Save reference to the package on the object
+                harvest_object.package_id = package_dict['id']
+                harvest_object.add()
 
-            # Save reference to the package on the object
-            harvest_object.package_id = package_dict['id']
-            harvest_object.add()
+                # Defer constraints and flush so the dataset can be indexed with
+                # the harvest object id (on the after_show hook from the harvester
+                # plugin)
+                model.Session.execute(
+                    'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
+                model.Session.flush()
 
-            # Defer constraints and flush so the dataset can be indexed with
-            # the harvest object id (on the after_show hook from the harvester
-            # plugin)
-            model.Session.execute(
-                'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
-            model.Session.flush()
+            elif status == 'change':
+                package_dict['id'] = harvest_object.package_id
 
-        elif status == 'change':
-            package_dict['id'] = harvest_object.package_id
-
-        if status in ['new', 'change']:
-            try:
+            if status in ['new', 'change']:
                 action = 'package_create' if status == 'new' else 'package_update'
                 message_status = 'Created' if status == 'new' else 'Updated'
 
                 package_id = p.toolkit.get_action(action)(context, package_dict)
                 log.info('%s dataset with id %s', message_status, package_id)
-            except p.toolkit.ValidationError, e:
-                self._save_object_error('Validation Error: %s' % str(e), harvest_object, 'Import')
-                return False
 
-        model.Session.commit()
+        except Exception, e:
+            dataset = json.loads(harvest_object.content)
+            dataset_name = dataset.get('name', '')
+
+            self._save_object_error('Error importing dataset %s: %r / %s' % (dataset_name, e, traceback.format_exc()), harvest_object, 'Import')
+            return False
+
+        finally:
+            model.Session.commit()
 
         return True
 

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -1,14 +1,32 @@
 import httpretty
+from mock import call, patch
+
 import nose
 
+from ckan.logic import ValidationError
 import ckantoolkit.tests.helpers as h
 
-from ckanext.dcat.harvesters._json import copy_across_resource_ids
+import ckan.tests.factories as factories
+
+from ckanext.dcat.harvesters._json import copy_across_resource_ids, DCATJSONHarvester
 from test_harvester import FunctionalHarvestTest
 
 eq_ = nose.tools.eq_
 
 class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
+
+    # invalid tags dataset
+    json_content_invalid_tags = '''
+        {
+        "@type": "dcat:Dataset",
+        "identifier": "http://example.com/datasets/invalid_example",
+        "title": "Example dataset with invalid tags",
+        "description": "Invalid keywords",
+        "publisher": {"name":"Example Department of Wildlife"},
+        "license": "https://example.com/license",
+        "keyword": ["example", "test's", "invalid & wrong"]
+        }
+    '''
 
     @classmethod
     def setup_class(cls):
@@ -61,14 +79,21 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
 }
         '''
 
+        # invalid_tags dataset
+        cls.json_content_invalid_tags_dataset = '{"dataset":[%s]}' % cls.json_content_invalid_tags
+
     def test_harvest_create(self):
 
         self._test_harvest_create(self.json_mock_url,
                                   self.json_content,
-                                  self.json_content_type)
+                                  self.json_content_type,
+                                  exp_titles=['Example dataset 1', 'Example dataset 2'])
 
-    def _test_harvest_create(self, url, content, content_type, num_datasets=2,
-                             **kwargs):
+    def _test_harvest_create(
+        self, url, content, content_type, num_datasets=2,
+        exp_num_datasets=2, exp_titles=[],
+        **kwargs
+    ):
 
         # Mock the GET request to get the file
         httpretty.register_uri(httpretty.GET, url,
@@ -87,16 +112,15 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
         fq = "+type:dataset harvest_source_id:{0}".format(harvest_source['id'])
         results = h.call_action('package_search', {}, fq=fq)
 
-        eq_(results['count'], num_datasets)
-        for result in results['results']:
-            assert result['title'] in ('Example dataset 1',
-                                       'Example dataset 2')
+        eq_(results['count'], exp_num_datasets)
+
+        if exp_titles:
+            for result in results['results']:
+                assert result['title'] in exp_titles
 
     def test_harvest_update_existing_resources(self):
 
         content = self.json_content_with_distribution
-        # content_modified = content.replace('Example dataset 1',
-        #                                    'Example dataset 1 (updated)')
         existing_resources, new_resources = \
             self._test_harvest_twice(content, content)
 
@@ -178,6 +202,14 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
 
         return (existing_resources, new_resources)
 
+    def test_harvest_does_not_create_with_invalid_tags(self):
+        self._test_harvest_create(
+            'http://some.dcat.file.invalid.json',
+            self.json_content_invalid_tags_dataset,
+            self.json_content_type,
+            num_datasets=1,
+            exp_num_datasets=0)
+
 
 class TestCopyAcrossResourceIds:
     def test_copied_because_same_uri(self):
@@ -238,3 +270,55 @@ class TestCopyAcrossResourceIds:
             harvested_dataset,
         )
         eq_(harvested_dataset['resources'][0].get('id'), None)
+
+
+class TestImportStage:
+
+    @classmethod
+    def setup_class(cls):
+        h.reset_db()
+
+    class MockHarvestObject:
+        guid = 'test_guid'
+        content = TestDCATJSONHarvestFunctional.json_content_invalid_tags
+
+        class MockStatus:
+            key = 'status'
+            value = 'new'
+
+        extras = [MockStatus()]
+        package = None
+
+        class MockSource:
+            id = 'test_id'
+
+        source = MockSource()
+
+        def add(self):
+            pass
+
+    class MockSourceDataset:
+        def __init__(self, owner_org=None):
+            self.owner_org = owner_org['id']
+
+    @patch('ckanext.dcat.harvesters._json.model.Package.get')
+    @patch('ckanext.dcat.harvesters._json.DCATJSONHarvester._save_object_error')
+    def test_import_invalid_tags(
+        self, mock_save_object_error, mock_model_package_get
+    ):
+        user = factories.User()
+        owner_org = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
+
+        mock_model_package_get.return_value = self.MockSourceDataset(owner_org)
+
+        harvester = DCATJSONHarvester()
+
+        mock_harvest_object = self.MockHarvestObject()
+        harvester.import_stage(mock_harvest_object)
+
+        args, _ = mock_save_object_error.call_args_list[0]
+
+        assert 'Validation Error:' in args[0]
+        assert '{\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}' in args[0]

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -323,26 +323,3 @@ class TestImportStage:
 
         assert 'Error importing dataset Invalid tags: ValidationError(None,)' in args[0]
         assert '{\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}' in args[0]
-
-    @patch('ckanext.dcat.harvesters._json.model.Package.get')
-    @patch('ckanext.dcat.harvesters._json.DCATJSONHarvester._save_object_error')
-    @patch('ckan.logic.schema.default_create_package_schema')
-    def test_import_invalid_tags_raise_generic_exception(
-        self, mock_default_create_package_schema, mock_save_object_error, mock_model_package_get
-    ):
-        mock_default_create_package_schema.side_effect = Exception('Internal Server Error')
-        user = factories.User()
-        owner_org = factories.Organization(
-            users=[{'name': user['id'], 'capacity': 'admin'}]
-        )
-
-        mock_model_package_get.return_value = self.MockSourceDataset(owner_org)
-
-        harvester = DCATJSONHarvester()
-
-        mock_harvest_object = self.MockHarvestObject()
-        harvester.import_stage(mock_harvest_object)
-
-        args, _ = mock_save_object_error.call_args_list[0]
-
-        assert "Error importing dataset Invalid tags: Exception('Internal Server Error',)" in args[0]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.3.2
 httpretty==0.6.2
+mock==2.0.0


### PR DESCRIPTION
## What

Our fetch process had stopped because of Validation Errors which were not properly handled in the `import_stage` this would eventually lead to the process dying after a number of retries. The end user would be unaware of any problems with the data as the status of the job is not updated.

## How to review

2 tests have been added to demonstrate the new behaviour which fixes the issue: 

`test_harvest_does_not_create_with_invalid_tags` -  demonstrates that it will not create the dataset with invalid data.

`test_import_invalid_tags` - checks that a Validation Error is handled and would be stored in an error log which the end user will have visibility of.