### PR TITLE
Fix deletion in JSON Harvester

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -165,11 +165,9 @@ class DCATJSONHarvester(DCATHarvester):
                 guid=guid, job=harvest_job,
                 package_id=guid_to_package_id[guid],
                 extras=[HarvestObjectExtra(key='status', value='delete')])
-            ids.append(obj.id)
-            model.Session.query(HarvestObject).\
-                filter_by(guid=guid).\
-                update({'current': False}, False)
             obj.save()
+            ids.append(obj.id)
+
 
         return ids
 
@@ -196,6 +194,11 @@ class DCATJSONHarvester(DCATHarvester):
                 context, {'id': harvest_object.package_id})
             log.info('Deleted package {0} with guid {1}'
                      .format(harvest_object.package_id, harvest_object.guid))
+
+            model.Session.query(HarvestObject).\
+                filter_by(guid=harvest_object.guid).\
+                filter_by(current=True).\
+                update({'current': False}, False)
 
             return True
 


### PR DESCRIPTION
Deletion in the JSON harvester is broken in 2 ways

* The json harvester crashes in the import stage when it can't access the harvest object id: None, because the id is queued before it is generated in obj.save()
* All of the harvest objects for the deleted dataset are set to not current before the crash, so the relationship between the dataset and the harvester is lost, so the dataset will live on in CKAN when it has been deleted from the source. 

This patch fixes the crash by saving the harvest object prior to using it's id, and only clearing the harvest objects for the deleted item after it has been deleted. 

