### PR TITLE
Support JSON-LD catalogs with @graph

### DIFF
--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -67,7 +67,7 @@ class RDFProcessor(object):
                 config.get(COMPAT_MODE_CONFIG_OPTION, False))
         self.compatibility_mode = compatibility_mode
 
-        self.g = rdflib.Graph()
+        self.g = rdflib.ConjunctiveGraph()
 
     def _load_profiles(self, profile_names):
         '''

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -652,6 +652,35 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         eq_(resource['url'], u'https://data.agency.gov/datasets/widgets-statistics/widgets.csv')
         eq_(resource['download_url'], u'https://data.agency.gov/datasets/widgets-statistics/widgets.csv')
 
+    def test_dataset_json_ld_with_at_graph(self):
+
+        contents = self._get_file_contents('catalog_with_at_graph.jsonld')
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+
+        p.parse(contents, _format='json-ld')
+
+        datasets = [d for d in p.datasets()]
+
+        eq_(len(datasets), 1)
+
+        dataset = datasets[0]
+        extras = dict((e['key'], e['value']) for e in dataset['extras'])
+
+        eq_(dataset['title'], 'Title dataset')
+
+        eq_(extras['contact_name'], 'Jane Doe')
+        # mailto gets removed for storage and is added again on output
+        eq_(extras['contact_email'], 'jane.doe@agency.gov')
+
+        eq_(len(dataset['resources']), 1)
+
+        resource = dataset['resources'][0]
+        eq_(resource['name'], u'download.zip')
+        eq_(resource['url'], u'http://example2.org/files/download.zip')
+        eq_(resource['access_url'], u'https://ckan.example.org/dataset/d4ce4e6e-ab89-44cb-bf5c-33a162c234de/resource/a289c289-55c9-410f-b4c7-f88e5f6f4e47')
+        eq_(resource['download_url'], u'http://example2.org/files/download.zip')
+
     def test_dataset_compatibility_mode(self):
 
         contents = self._get_file_contents('dataset.rdf')

--- a/examples/catalog_with_at_graph.jsonld
+++ b/examples/catalog_with_at_graph.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "vcard": "http://www.w3.org/2006/vcard/ns#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "https://example.org#catalog",
+      "@type": "dcat:Catalog",
+      "dcat:dataset": {
+        "@id": "https://ckan.example.org/dataset/d4ce4e6e-ab89-44cb-bf5c-33a162c234de#dataset"
+      },
+      "dcterms:description": "Description example.org",
+      "dcterms:publisher": {
+        "@id": "https://www.example.org/impressum#publisher"
+      },
+      "dcterms:title": "Title example.org"
+    },
+    {
+      "@id": "https://www.example.org/impressum#publisher",
+      "@type": "foaf:Organization",
+      "foaf:name": "Organization example.org"
+    },
+    {
+      "@id": "https://ckan.example.org/dataset/d4ce4e6e-ab89-44cb-bf5c-33a162c234de#dataset",
+      "@type": "dcat:Dataset",
+      "dcat:contactPoint": {
+        "@id": "_:ub1365bL31C21"
+      },
+      "dcat:distribution": {
+        "@id": "https://ckan.example.org/dataset/d4ce4e6e-ab89-44cb-bf5c-33a162c234de/resource/a289c289-55c9-410f-b4c7-f88e5f6f4e47#distribution"
+      },
+      "dcterms:description": "Description distribution",
+      "dcterms:title": "Title dataset"
+    },
+    {
+      "@id": "_:ub1365bL31C21",
+      "@type": "vcard:Individual",
+      "vcard:fn": "Jane Doe",
+      "vcard:hasEmail": "mailto:jane.doe@agency.gov",
+      "vcard:hasTelephone": "+49 40 123 45678"
+    },
+    {
+      "@id": "https://ckan.example.org/dataset/d4ce4e6e-ab89-44cb-bf5c-33a162c234de/resource/a289c289-55c9-410f-b4c7-f88e5f6f4e47#distribution",
+      "@type": "dcat:Distribution",
+      "dcterms:title": "download.zip",
+      "dcat:accessURL": {
+        "@id": "https://ckan.example.org/dataset/d4ce4e6e-ab89-44cb-bf5c-33a162c234de/resource/a289c289-55c9-410f-b4c7-f88e5f6f4e47"
+      },
+      "dcat:downloadURL": {
+        "@id": "http://example2.org/files/download.zip"
+      },
+      "dcterms:license": {
+        "@id": "http://www.opendefinition.org/licenses/cc-zero"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for parsing JSON-LD catalogs containing `@graph` elements.

Links to open issues in rdflib-jsonld relating this problem:
- https://github.com/RDFLib/rdflib-jsonld/issues/40
- https://github.com/RDFLib/rdflib-jsonld/issues/53

The suggested "solution" is to use `rdflib.ConjunctiveGraph()` instead of `rdflib.Graph()`.