### PR TITLE
Extract read datasets from db to make it re-usable

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -149,11 +149,9 @@ class DCATHarvester(HarvesterBase):
             return obj.source.url
         return None
 
-    def _get_existing_dataset(self, guid):
+    def _read_datasets_from_db(self, guid):
         '''
-        Checks if a dataset with a certain guid extra already exists
-
-        Returns a dict as the ones returned by package_show
+        Returns a database result of datasets matching the given guid.
         '''
 
         datasets = model.Session.query(model.Package.id) \
@@ -162,6 +160,16 @@ class DCATHarvester(HarvesterBase):
                                 .filter(model.PackageExtra.value == guid) \
                                 .filter(model.Package.state == 'active') \
                                 .all()
+        return datasets
+
+    def _get_existing_dataset(self, guid):
+        '''
+        Checks if a dataset with a certain guid extra already exists
+
+        Returns a dict as the ones returned by package_show
+        '''
+
+        datasets = self._read_datasets_from_db(guid)
 
         if not datasets:
             return None


### PR DESCRIPTION
Moves the code for reading datasets by the guid into a separate method to make it possible to re-use the method instead of using the method `_get_existing_datasets` (calls package_show additionally which is unnecessary in our case) or copy paste the code in our harvester implementation.