### PR TITLE
Fix format normalization configuration

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -947,8 +947,8 @@ class EuropeanDCATAPProfile(RDFProfile):
                     resource_dict[key] = json.dumps(values)
 
             # Format and media type
-            normalize_ckan_format = config.get(
-                'ckanext.dcat.normalize_ckan_format', True)
+            normalize_ckan_format = toolkit.asbool(config.get(
+                'ckanext.dcat.normalize_ckan_format', True))
             imt, label = self._distribution_format(distribution,
                                                    normalize_ckan_format)
 

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -364,6 +364,7 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         resource = datasets[0]['resources'][0]
 
         eq_(resource['format'], u'CSV')
+        assert 'mimetype' not in resource
 
     def test_distribution_format_imt_only(self):
         g = Graph()
@@ -389,7 +390,7 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         else:
             eq_(resource['format'], u'text/csv')
 
-    @helpers.change_config('ckanext.dcat.normalize_ckan_format', False)
+    @helpers.change_config('ckanext.dcat.normalize_ckan_format', 'False')
     def test_distribution_format_imt_only_normalize_false(self):
         g = Graph()
 
@@ -412,8 +413,8 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         eq_(resource['format'], u'text/csv')
         eq_(resource['mimetype'], u'text/csv')
 
-    @helpers.change_config('ckanext.dcat.normalize_ckan_format', False)
-    def test_distribution_format_format_only_normalize_false(self):
+    @helpers.change_config('ckanext.dcat.normalize_ckan_format', 'False')
+    def test_distribution_format_format_only_without_slash_normalize_false(self):
         g = Graph()
 
         dataset1 = URIRef("http://example.org/datasets/1")
@@ -421,7 +422,7 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
 
         distribution1_1 = URIRef("http://example.org/datasets/1/ds/1")
         g.add((distribution1_1, RDF.type, DCAT.Distribution))
-        g.add((distribution1_1, DCT['format'], Literal('CSV')))
+        g.add((distribution1_1, DCT['format'], Literal('Comma Separated Values')))
         g.add((dataset1, DCAT.distribution, distribution1_1))
 
         p = RDFParser(profiles=['euro_dcat_ap'])
@@ -432,8 +433,31 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
 
         resource = datasets[0]['resources'][0]
 
-        eq_(resource['format'], u'CSV')
+        eq_(resource['format'], u'Comma Separated Values')
         assert 'mimetype' not in resource
+
+    @helpers.change_config('ckanext.dcat.normalize_ckan_format', 'False')
+    def test_distribution_format_format_only_with_slash_normalize_false(self):
+        g = Graph()
+
+        dataset1 = URIRef("http://example.org/datasets/1")
+        g.add((dataset1, RDF.type, DCAT.Dataset))
+
+        distribution1_1 = URIRef("http://example.org/datasets/1/ds/1")
+        g.add((distribution1_1, RDF.type, DCAT.Distribution))
+        g.add((distribution1_1, DCT['format'], Literal('text/csv')))
+        g.add((dataset1, DCAT.distribution, distribution1_1))
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+
+        p.g = g
+
+        datasets = [d for d in p.datasets()]
+
+        resource = datasets[0]['resources'][0]
+
+        eq_(resource['format'], u'text/csv')
+        eq_(resource['mimetype'], u'text/csv')
 
     def test_distribution_format_unknown_imt(self):
         g = Graph()


### PR DESCRIPTION
We wanted to deactivate the ckan format normalization by config. But we are surprised that the config parameter `ckanext.dcat.normalize_ckan_format` seems to be ignored. We invested some time and found out the reason.
The reason is that the config parameter was read from the config file but was interpreted as string what is still the default behavior for an ini file. So, the value `False` in the config file was interpreted as string `'False'` and not as boolean what will lead to the situation that the expression `and normalize_ckan_format` was always True, because a not empty string is interpreted as True.

The pull request adds the conversion of the param to type boolean.