### PR TITLE
Introduce the possibility to modify package update/create schema

### DIFF
--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -308,7 +308,13 @@ class DCATRDFHarvester(DCATHarvester):
         existing_dataset = self._get_existing_dataset(harvest_object.guid)
 
         try:
+            package_plugin = lib_plugins.lookup_package_plugin(dataset.get('type', None))
             if existing_dataset:
+                package_schema = package_plugin.update_package_schema()
+                for harvester in p.PluginImplementations(IDCATRDFHarvester):
+                    package_schema = harvester.update_package_schema_for_update(package_schema)
+                context['schema'] = package_schema
+
                 # Don't change the dataset name even if the title has
                 dataset['name'] = existing_dataset['name']
                 dataset['id'] = existing_dataset['id']
@@ -350,9 +356,9 @@ class DCATRDFHarvester(DCATHarvester):
                 log.info('Updated dataset %s' % dataset['name'])
 
             else:
-                package_plugin = lib_plugins.lookup_package_plugin(dataset.get('type', None))
-
                 package_schema = package_plugin.create_package_schema()
+                for harvester in p.PluginImplementations(IDCATRDFHarvester):
+                    package_schema = harvester.update_package_schema_for_create(package_schema)
                 context['schema'] = package_schema
 
                 # We need to explicitly provide a package ID

--- a/ckanext/dcat/interfaces.py
+++ b/ckanext/dcat/interfaces.py
@@ -166,3 +166,27 @@ class IDCATRDFHarvester(Interface):
         :rtype: string
         '''
         return None
+
+    def update_package_schema_for_create(self, package_schema):
+        '''
+        Called just before the ``package_create`` action.
+
+        :param package_schema: The default create package schema dict.
+        :type package_schema_dict: dict
+
+        :returns: The updated package_schema object
+        :rtype: object
+        '''
+        return package_schema
+
+    def update_package_schema_for_update(self, package_schema):
+        '''
+        Called just before the ``package_update`` action.
+
+        :param package_schema: The default update package schema dict.
+        :type package_schema_dict: dict
+
+        :returns: The updated package_schema object
+        :rtype: object
+        '''
+        return package_schema

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -106,6 +106,16 @@ class TestRDFHarvester(p.SingletonPlugin):
         self.calls['after_create'] += 1
         return None
 
+    def update_package_schema_for_create(self, package_schema):
+        self.calls['update_package_schema_for_create'] += 1
+        package_schema['new_key'] = 'test'
+        return package_schema
+
+    def update_package_schema_for_update(self, package_schema):
+        self.calls['update_package_schema_for_update'] += 1
+        package_schema['new_key'] = 'test'
+        return package_schema
+
 
 class TestRDFNullHarvester(TestRDFHarvester):
     p.implements(IDCATRDFHarvester)
@@ -1297,8 +1307,10 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         last_job_status = harvest_source['status']['last_job']
         eq_(last_job_status['status'], 'Finished')
 
+        eq_(plugin.calls['update_package_schema_for_create'], 2)
         eq_(plugin.calls['before_create'], 2)
         eq_(plugin.calls['after_create'], 2)
+        eq_(plugin.calls['update_package_schema_for_update'], 0)
         eq_(plugin.calls['before_update'], 0)
         eq_(plugin.calls['after_update'], 0)
 
@@ -1311,8 +1323,10 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         # Run a second job
         self._run_full_job(harvest_source['id'], num_objects=2)
 
+        eq_(plugin.calls['update_package_schema_for_create'], 2)
         eq_(plugin.calls['before_create'], 2)
         eq_(plugin.calls['after_create'], 2)
+        eq_(plugin.calls['update_package_schema_for_update'], 2)
         eq_(plugin.calls['before_update'], 2)
         eq_(plugin.calls['after_update'], 2)
 
@@ -1380,8 +1394,10 @@ class TestDCATHarvestFunctionalSetNull(FunctionalHarvestTest):
             }
         )
 
+        eq_(plugin.calls['update_package_schema_for_create'], 2)
         eq_(plugin.calls['before_create'], 2)
         eq_(plugin.calls['after_create'], 0)
+        eq_(plugin.calls['update_package_schema_for_update'], 0)
         eq_(plugin.calls['before_update'], 0)
         eq_(plugin.calls['after_update'], 0)
 
@@ -1452,8 +1468,10 @@ class TestDCATHarvestFunctionalRaiseExcpetion(FunctionalHarvestTest):
             }
         )
 
+        eq_(plugin.calls['update_package_schema_for_create'], 2)
         eq_(plugin.calls['before_create'], 2)
         eq_(plugin.calls['after_create'], 1)
+        eq_(plugin.calls['update_package_schema_for_update'], 0)
         eq_(plugin.calls['before_update'], 0)
         eq_(plugin.calls['after_update'], 0)
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -1518,3 +1518,23 @@ class TestIDCATRDFHarvester(object):
 
         eq_(values[0], content)
         eq_(values[1], [])
+
+    def test_update_package_schema_for_create(self):
+
+        i = IDCATRDFHarvester()
+
+        package_schema = dict(some_validator='some.content')
+
+        value = i.update_package_schema_for_create(package_schema)
+
+        eq_(value, package_schema)
+
+    def test_update_package_schema_for_update(self):
+
+        i = IDCATRDFHarvester()
+
+        package_schema = dict(some_validator='some.content')
+
+        value = i.update_package_schema_for_update(package_schema)
+
+        eq_(value, package_schema)


### PR DESCRIPTION
We want to deactivate the email validation for the fields `author_email` and `maintainer_email`, because we would not like to reject the import of a dataset if the email address is invalid.

The pull request introduces the possibility to modify/overwrite the update/create package schema used in the harvest process updating/creating datasets. This can be done by implementing the new interface methods `update_package_schema_for_create` and `update_package_schema_for_update`.