### PR TITLE
Add support for DCT.rightsStatement in DCT.accessRights and DCT.rights

### DIFF
--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -251,6 +251,37 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         dataset = [d for d in p.datasets()][0]
         eq_(dataset['license_id'], 'cc-by')
 
+    def test_dataset_access_rights_and_distribution_rights_rights_statement(self):
+        # license_id retrieved from the URI of dcat:license object
+        g = Graph()
+
+        dataset_ref = URIRef("http://example.org/datasets/1")
+        g.add((dataset_ref, RDF.type, DCAT.Dataset))
+
+        # access_rights
+        access_rights = BNode()
+        g.add((access_rights, RDF.type, DCT.RightsStatement))
+        g.add((access_rights, RDFS.label, Literal('public dataset')))
+        g.add((dataset_ref, DCT.accessRights, access_rights))
+        # rights
+        rights = BNode()
+        g.add((rights, RDF.type, DCT.RightsStatement))
+        g.add((rights, RDFS.label, Literal('public distribution')))
+        distribution = URIRef("http://example.org/datasets/1/ds/1")
+        g.add((dataset_ref, DCAT.distribution, distribution))
+        g.add((distribution, RDF.type, DCAT.Distribution))
+        g.add((distribution, DCT.rights, rights))
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+
+        p.g = g
+
+        dataset = [d for d in p.datasets()][0]
+        extras = self._extras(dataset)
+        eq_(extras['access_rights'], 'public dataset')
+        resource = dataset['resources'][0]
+        eq_(resource['rights'], 'public distribution')
+
     def test_distribution_access_url(self):
         g = Graph()
 


### PR DESCRIPTION
The pull request adds support for DCT.rightsStatement in DCT.accessRights (DCAT.Dataset) and DCT.rights (DCAT.Distribution).

* Dataset.accessRights: https://www.w3.org/TR/vocab-dcat-2/#Property:resource_access_rights
* Distribution.rights: https://www.w3.org/TR/vocab-dcat-2/#Property:distribution_rights

The old behavior was to save the NodeID of the element <dct:RightsStatement>, the new behavior reads the literal in rdf:label nested in <dct:RightsStatement> and save this.

```
<dcat:Dataset rdf:about="https://data.some.org/catalog/datasets/9df8df51-63db-37a8-e044-0003ba9b0d98">
  <dct:accessRights>
    <dct:RightsStatement>
      <rdfs:label>public</rdfs:label>
    </dct:RightsStatement>
  </dct:accessRights>
  <dcat:distribution>
    <dcat:Distribution rdf:about="https://data.some.org/catalog/datasets/9df8df51-63db-37a8-e044-0003ba9b0d98/1">
      <dct:rights>
        <dct:RightsStatement>
          <rdfs:label>Some statement about rights</rdfs:label>
        </dct:RightsStatement>
      </dct:rights>
    </dcat:Distribution>
  </dcat:distribution>
</dcat:Dataset>
```

The example above will be now saved as

| Field | Value |
| --- | --- |
| Dataset.access_rights | public |
| Resource.rights | Some statement about rights |
