### PR TITLE
Add a response passthru for solr_url config

### DIFF
--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -18,8 +18,9 @@ from ckanext.harvest import queue
 from ckanext.dcat.harvesters import DCATRDFHarvester
 from ckanext.dcat.interfaces import IDCATRDFHarvester
 import ckanext.dcat.harvesters.rdf
+from ckantoolkit import config
 
-responses.add_passthru('http://127.0.0.1:8983/solr')
+responses.add_passthru(config.get('solr_url', 'http://127.0.0.1:8983/solr'))
 
 
 # TODO move to ckanext-harvest


### PR DESCRIPTION
## What

Without the response passthru the harvest tests will fail with an external redirect detected.

This will allow tests to pass on a docker dev stack.