### PR TITLE
Remove beautifulsoup4 from dev_requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-beautifulsoup4==4.3.2
 responses==0.10.9
 mock==2.0.0
 pytest-ckan


### PR DESCRIPTION
It doesn't appear to be used anywhere and causes errors when used with Python 3.5+ (see ckan/ckanext-dcat#192).