### PR TITLE
Introduce interface method `after_parsing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.1.0...HEAD)
 
 * TBD
+* Introduce new interface method `after_parsing`
 
 ## [v1.1.1](https://github.com/ckan/ckanext-dcat/compare/v1.1.0...v1.1.1) - 2021-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
-## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.1.0...HEAD)
+## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.1.1...HEAD)
 
-* TBD
-* Introduce new interface method `after_parsing`
+* Introduce new interface method `after_parsing` (#196)
 
 ## [v1.1.1](https://github.com/ckan/ckanext-dcat/compare/v1.1.0...v1.1.1) - 2021-03-17
 

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -214,6 +214,9 @@ class DCATRDFHarvester(DCATHarvester):
                 for error_msg in after_parsing_errors:
                     self._save_gather_error(error_msg, harvest_job)
 
+            if not parser:
+                return []
+
             try:
 
                 source_dataset = model.Package.get(harvest_job.source.id)

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -208,6 +208,12 @@ class DCATRDFHarvester(DCATHarvester):
                 self._save_gather_error('Error parsing the RDF file: {0}'.format(e), harvest_job)
                 return []
 
+            for harvester in p.PluginImplementations(IDCATRDFHarvester):
+                parser, after_parsing_errors = harvester.after_parsing(parser, harvest_job)
+
+                for error_msg in after_parsing_errors:
+                    self._save_gather_error(error_msg, harvest_job)
+
             try:
 
                 source_dataset = model.Package.get(harvest_job.source.id)

--- a/ckanext/dcat/interfaces.py
+++ b/ckanext/dcat/interfaces.py
@@ -78,6 +78,33 @@ class IDCATRDFHarvester(Interface):
         '''
         return content, []
 
+    def after_parsing(self, rdf_parser, harvest_job):
+        '''
+        Called just after the content from the remote RDF file has been parsed
+
+        It returns a tuple with the parser (which can be modified) and an
+        optional list of error messages.
+
+        This extension point can be useful to work with the graph and put it to
+        other stores, e.g. a triple store.
+
+        :param rdf_parser: The RDF parser with the remote content as a graph object
+        :type rdf_parser: ckanext.dcat.processors.RDFParser
+        :param harvest_job: A ``HarvestJob`` domain object which contains a
+                            reference to the harvest source
+                            (``harvest_job.source``).
+        :type harvest_job: object
+
+
+        :returns: A tuple with two items:
+                    * The RDF parser. If this is False the gather stage will
+                      stop.
+                    * A list of error messages. These will get stored as gather
+                      errors by the harvester
+        :rtype: tuple
+        '''
+        return rdf_parser, []
+
     def before_update(self, harvest_object, dataset_dict, temp_dict):
         '''
         Called just before the ``package_update`` action.

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -76,6 +76,17 @@ class TestRDFHarvester(p.SingletonPlugin):
         else:
             return content, []
 
+    def after_parsing(self, rdf_parser, harvest_job):
+
+        self.calls['after_parsing'] += 1
+
+        if rdf_parser == 'return.empty.rdf_parser':
+            return None, []
+        elif rdf_parser == 'return.errors':
+            return None, ['Error 1', 'Error 2']
+        else:
+            return rdf_parser, []
+
     def before_update(self, harvest_object, dataset_dict, temp_dict):
         self.calls['before_update'] += 1
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -1304,38 +1304,43 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         plugin = p.get_plugin('test_rdf_harvester')
         plugin.after_parsing_mode = 'return.empty.rdf_parser'
 
-        url = self.rdf_mock_url
-        content =  self.rdf_content
-        content_type = self.rdf_content_type
+        # ensure after_parsing_mode is reset, so wrap in try..finally block
+        try:
+            url = self.rdf_mock_url
+            content =  self.rdf_content
+            content_type = self.rdf_content_type
 
-        # Mock the GET request to get the file
-        responses.add(responses.GET, url,
-                               body=content, content_type=content_type)
+            # Mock the GET request to get the file
+            responses.add(responses.GET, url,
+                                body=content, content_type=content_type)
 
-        # The harvester will try to do a HEAD request first so we need to mock
-        # this as well
-        responses.add(responses.HEAD, url,
-                               status=405, content_type=content_type)
+            # The harvester will try to do a HEAD request first so we need to mock
+            # this as well
+            responses.add(responses.HEAD, url,
+                                status=405, content_type=content_type)
 
-        harvest_source = self._create_harvest_source(self.rdf_mock_url)
-        self._create_harvest_job(harvest_source['id'])
-        self._run_jobs(harvest_source['id'])
-        self._gather_queue(1)
+            harvest_source = self._create_harvest_source(self.rdf_mock_url)
+            self._create_harvest_job(harvest_source['id'])
+            self._run_jobs(harvest_source['id'])
+            self._gather_queue(1)
 
-        assert plugin.calls['after_parsing'] == 1
+            assert plugin.calls['after_parsing'] == 1
 
-        # Run the jobs to mark the previous one as Finished
-        self._run_jobs()
+            # Run the jobs to mark the previous one as Finished
+            self._run_jobs()
 
-        # Get the harvest source with the updated status
-        harvest_source = helpers.call_action('harvest_source_show',
-                                       id=harvest_source['id'])
+            # Get the harvest source with the updated status
+            harvest_source = helpers.call_action('harvest_source_show',
+                                        id=harvest_source['id'])
 
-        last_job_status = harvest_source['status']['last_job']
+            last_job_status = harvest_source['status']['last_job']
 
-        assert last_job_status['status'] == 'Finished'
+            assert last_job_status['status'] == 'Finished'
 
-        assert last_job_status['stats']['added'] == 0
+            assert last_job_status['stats']['added'] == 0
+        finally:
+            plugin.after_parsing_mode = ''
+
 
     @responses.activate
     def test_harvest_after_parsing_errors_get_stored(self, reset_calls_counter):
@@ -1344,38 +1349,41 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         plugin = p.get_plugin('test_rdf_harvester')
         plugin.after_parsing_mode = 'return.errors'
 
-        url = self.rdf_mock_url
-        content =  self.rdf_content
-        content_type = self.rdf_content_type
+        # ensure after_parsing_mode is reset, so wrap in try..finally block
+        try:
+            url = self.rdf_mock_url
+            content =  self.rdf_content
+            content_type = self.rdf_content_type
 
-        # Mock the GET request to get the file
-        responses.add(responses.GET, url,
-                               body=content, content_type=content_type)
+            # Mock the GET request to get the file
+            responses.add(responses.GET, url,
+                                body=content, content_type=content_type)
 
-        # The harvester will try to do a HEAD request first so we need to mock
-        # this as well
-        responses.add(responses.HEAD, url,
-                               status=405, content_type=content_type)
+            # The harvester will try to do a HEAD request first so we need to mock
+            # this as well
+            responses.add(responses.HEAD, url,
+                                status=405, content_type=content_type)
 
-        harvest_source = self._create_harvest_source(self.rdf_mock_url)
-        self._create_harvest_job(harvest_source['id'])
-        self._run_jobs(harvest_source['id'])
-        self._gather_queue(1)
+            harvest_source = self._create_harvest_source(self.rdf_mock_url)
+            self._create_harvest_job(harvest_source['id'])
+            self._run_jobs(harvest_source['id'])
+            self._gather_queue(1)
 
-        assert plugin.calls['after_parsing'] == 1
+            assert plugin.calls['after_parsing'] == 1
 
-        # Run the jobs to mark the previous one as Finished
-        self._run_jobs()
+            # Run the jobs to mark the previous one as Finished
+            self._run_jobs()
 
-        # Get the harvest source with the updated status
-        harvest_source = helpers.call_action('harvest_source_show',
-                                       id=harvest_source['id'])
+            # Get the harvest source with the updated status
+            harvest_source = helpers.call_action('harvest_source_show',
+                                        id=harvest_source['id'])
 
-        last_job_status = harvest_source['status']['last_job']
+            last_job_status = harvest_source['status']['last_job']
 
-        assert 'Error 1' == last_job_status['gather_error_summary'][0][0]
-        assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
-
+            assert 'Error 1' == last_job_status['gather_error_summary'][0][0]
+            assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
+        finally:
+            plugin.after_parsing_mode = ''
 
     @responses.activate
     def test_harvest_import_extensions_point_gets_called(self, reset_calls_counter):

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -48,6 +48,8 @@ class TestRDFHarvester(p.SingletonPlugin):
     p.implements(IDCATRDFHarvester)
 
     calls = defaultdict(int)
+    # change return values of after_parsing via this parameter
+    after_parsing_mode = ''
 
     def before_download(self, url, harvest_job):
 
@@ -80,9 +82,9 @@ class TestRDFHarvester(p.SingletonPlugin):
 
         self.calls['after_parsing'] += 1
 
-        if rdf_parser == 'return.empty.rdf_parser':
+        if self.after_parsing_mode == 'return.empty.rdf_parser':
             return None, []
-        elif rdf_parser == 'return.errors':
+        elif self.after_parsing_mode == 'return.errors':
             return None, ['Error 1', 'Error 2']
         else:
             return rdf_parser, []
@@ -1270,6 +1272,112 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
         assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
 
     @responses.activate
+    def test_harvest_after_parsing_extension_point_gets_called(self, reset_calls_counter):
+
+        reset_calls_counter('test_rdf_harvester')
+        plugin = p.get_plugin('test_rdf_harvester')
+
+        url = self.rdf_mock_url
+        content =  self.rdf_content
+        content_type = self.rdf_content_type
+
+        # Mock the GET request to get the file
+        responses.add(responses.GET, url,
+                               body=content, content_type=content_type)
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well
+        responses.add(responses.HEAD, url,
+                               status=405, content_type=content_type)
+
+        harvest_source = self._create_harvest_source(self.rdf_mock_url)
+        self._create_harvest_job(harvest_source['id'])
+        self._run_jobs(harvest_source['id'])
+        self._gather_queue(1)
+
+        assert plugin.calls['after_parsing'] == 1
+
+    @responses.activate
+    def test_harvest_after_parsing_empty_content_stops_gather_stage(self, reset_calls_counter):
+
+        reset_calls_counter('test_rdf_harvester')
+        plugin = p.get_plugin('test_rdf_harvester')
+        plugin.after_parsing_mode = 'return.empty.rdf_parser'
+
+        url = self.rdf_mock_url
+        content =  self.rdf_content
+        content_type = self.rdf_content_type
+
+        # Mock the GET request to get the file
+        responses.add(responses.GET, url,
+                               body=content, content_type=content_type)
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well
+        responses.add(responses.HEAD, url,
+                               status=405, content_type=content_type)
+
+        harvest_source = self._create_harvest_source(self.rdf_mock_url)
+        self._create_harvest_job(harvest_source['id'])
+        self._run_jobs(harvest_source['id'])
+        self._gather_queue(1)
+
+        assert plugin.calls['after_parsing'] == 1
+
+        # Run the jobs to mark the previous one as Finished
+        self._run_jobs()
+
+        # Get the harvest source with the updated status
+        harvest_source = helpers.call_action('harvest_source_show',
+                                       id=harvest_source['id'])
+
+        last_job_status = harvest_source['status']['last_job']
+
+        assert last_job_status['status'] == 'Finished'
+
+        assert last_job_status['stats']['added'] == 0
+
+    @responses.activate
+    def test_harvest_after_parsing_errors_get_stored(self, reset_calls_counter):
+
+        reset_calls_counter('test_rdf_harvester')
+        plugin = p.get_plugin('test_rdf_harvester')
+        plugin.after_parsing_mode = 'return.errors'
+
+        url = self.rdf_mock_url
+        content =  self.rdf_content
+        content_type = self.rdf_content_type
+
+        # Mock the GET request to get the file
+        responses.add(responses.GET, url,
+                               body=content, content_type=content_type)
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well
+        responses.add(responses.HEAD, url,
+                               status=405, content_type=content_type)
+
+        harvest_source = self._create_harvest_source(self.rdf_mock_url)
+        self._create_harvest_job(harvest_source['id'])
+        self._run_jobs(harvest_source['id'])
+        self._gather_queue(1)
+
+        assert plugin.calls['after_parsing'] == 1
+
+        # Run the jobs to mark the previous one as Finished
+        self._run_jobs()
+
+        # Get the harvest source with the updated status
+        harvest_source = helpers.call_action('harvest_source_show',
+                                       id=harvest_source['id'])
+
+        last_job_status = harvest_source['status']['last_job']
+
+        assert 'Error 1' == last_job_status['gather_error_summary'][0][0]
+        assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
+
+
+    @responses.activate
     def test_harvest_import_extensions_point_gets_called(self, reset_calls_counter):
 
         reset_calls_counter('test_rdf_harvester')
@@ -1489,6 +1597,17 @@ class TestIDCATRDFHarvester(object):
         values = i.after_download(content, {})
 
         assert values[0] == content
+        assert values[1] == []
+
+    def test_after_parsing(self):
+
+        i = IDCATRDFHarvester()
+
+        rdf_parser = 'some.parser'
+
+        values = i.after_parsing(rdf_parser, {})
+
+        assert values[0] == rdf_parser
         assert values[1] == []
 
     def test_update_package_schema_for_create(self):


### PR DESCRIPTION
Adds a new harvester interface method which is called just after the content from the remote RDF file has been parsed.

It allows to interact with the RDF parser instance, which can be useful to work with the graph and put it to other stores, e.g. a triple store.