### PR TITLE
Fixes pagination URIs to use same logic as catalog_uri

### DIFF
--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -9,7 +9,7 @@ from ckan.plugins import toolkit
 import ckanext.dcat.converters as converters
 
 from ckanext.dcat.processors import RDFSerializer
-
+from ckanext.dcat.utils import catalog_uri
 
 DATASETS_PER_PAGE = 100
 
@@ -144,9 +144,7 @@ def _pagination_info(query, data_dict):
 
     def _page_url(page):
 
-        base_url = config.get('ckan.site_url', '').strip('/')
-        if not base_url:
-            base_url = toolkit.request.host_url
+        base_url = catalog_uri()
         base_url = '%s%s' % (
             base_url, toolkit.request.path)
 

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -241,9 +241,9 @@ class TestPagination(object):
         assert 'previous' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
-    @pytest.mark.ckan_config('ckan.site_url', '')
+    @pytest.mark.ckan_config('ckanext.dcat.base_uri', 'http://example.com/data')
     @mock.patch('ckan.plugins.toolkit.request')
-    def test_pagination_without_site_url(self, mock_request):
+    def test_pagination_with_dcat_base_uri(self, mock_request):
 
         mock_request.params = {}
         mock_request.host_url = 'http://ckan.example.com'
@@ -262,10 +262,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://ckan.example.com/feed/catalog.xml?page=1'
-        assert pagination['first'] == 'http://ckan.example.com/feed/catalog.xml?page=1'
-        assert pagination['last'] == 'http://ckan.example.com/feed/catalog.xml?page=2'
-        assert pagination['next'] == 'http://ckan.example.com/feed/catalog.xml?page=2'
+        assert pagination['current'] == 'http://example.com/data/feed/catalog.xml?page=1'
+        assert pagination['first'] == 'http://example.com/data/feed/catalog.xml?page=1'
+        assert pagination['last'] == 'http://example.com/data/feed/catalog.xml?page=2'
+        assert pagination['next'] == 'http://example.com/data/feed/catalog.xml?page=2'
         assert 'previous' not in pagination
 
     def test_pagination_no_results_empty_dict(self):


### PR DESCRIPTION
catalog_uri() contains logic for generating base uri based on configuration. Pagianation uses only site_url for base url, which results in wrong url when `ckanext.dcat.base_uri` is configured for example to `http://example.com/data` 

https://github.com/ckan/ckanext-dcat/blob/c285382e0c893a2dea7005729156f8bd3348ec54/ckanext/dcat/utils.py#L141-L158

