### PR TITLE
Use simplejson HTML encoder for structured data

### DIFF
--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -3,7 +3,7 @@
 from builtins import str
 import logging
 import uuid
-import json
+import simplejson as json
 import re
 import operator
 
@@ -133,7 +133,7 @@ def structured_data(dataset_id, profiles=None, _format='jsonld'):
     try:
         json_data = json.loads(data)
         return json.dumps(json_data, sort_keys=True,
-                          indent=4, separators=(',', ': '))
+                          indent=4, separators=(',', ': '), cls=json.JSONEncoderForHTML)
     except ValueError:
         # result was not JSON, return anyway
         return data


### PR DESCRIPTION
As structured data is rendered with safe filter, the content needs to be escaped as it is user provided and opens up many security considerations.

https://github.com/ckan/ckanext-dcat/blob/c285382e0c893a2dea7005729156f8bd3348ec54/ckanext/dcat/templates/package/read_base.html#L24