### PR TITLE
Also process URIRef in rights statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 
-## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.1.1...HEAD)
+## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.1.2...HEAD)
 
+* Also process URIRef in rights statements
 
 ## [v1.1.2](https://github.com/ckan/ckanext-dcat/compare/v1.1.2...v1.1.1) - 2021-06-22
 

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -458,7 +458,7 @@ class RDFProfile(object):
         if obj:
             if isinstance(obj, BNode) and self._object(obj, RDF.type) == DCT.RightsStatement:
                 result = self._object_value(obj, RDFS.label)
-            elif isinstance(obj, Literal):
+            elif isinstance(obj, Literal) or isinstance(obj, URIRef):
                 result = six.text_type(obj)
         return result
 

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_parse.py
@@ -321,7 +321,7 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         extras = self._extras(dataset)
         assert extras['contact_email'] == 'contact@some.org'
 
-    def test_dataset_access_rights_and_distribution_rights_rights_statement(self):
+    def test_dataset_access_rights_and_distribution_rights_rights_statement_literal(self):
         # license_id retrieved from the URI of dcat:license object
         g = Graph()
 
@@ -351,6 +351,36 @@ class TestEuroDCATAPProfileParsing(BaseParseTest):
         assert extras['access_rights'] == 'public dataset'
         resource = dataset['resources'][0]
         assert resource['rights'] == 'public distribution'
+
+    def test_dataset_access_rights_and_distribution_rights_rights_statement_uriref(self):
+        g = Graph()
+
+        dataset_ref = URIRef("http://example.org/datasets/1")
+        g.add((dataset_ref, RDF.type, DCAT.Dataset))
+
+        # access_rights
+        access_rights = BNode()
+        g.add((access_rights, RDF.type, DCT.RightsStatement))
+        g.add((access_rights, RDFS.label, URIRef("http://example.org/datasets/1/ds/3")))
+        g.add((dataset_ref, DCT.accessRights, access_rights))
+        # rights
+        rights = BNode()
+        g.add((rights, RDF.type, DCT.RightsStatement))
+        g.add((rights, RDFS.label, URIRef("http://example.org/datasets/1/ds/2")))
+        distribution = URIRef("http://example.org/datasets/1/ds/1")
+        g.add((dataset_ref, DCAT.distribution, distribution))
+        g.add((distribution, RDF.type, DCAT.Distribution))
+        g.add((distribution, DCT.rights, rights))
+
+        p = RDFParser(profiles=['euro_dcat_ap'])
+
+        p.g = g
+
+        dataset = [d for d in p.datasets()][0]
+        extras = self._extras(dataset)
+        assert extras['access_rights'] == 'http://example.org/datasets/1/ds/3'
+        resource = dataset['resources'][0]
+        assert resource['rights'] == 'http://example.org/datasets/1/ds/2'
 
     def test_distribution_access_url(self):
         g = Graph()


### PR DESCRIPTION
Rights statements might also contain an URI like <http://publications.europa.eu/resource/authority/access-right/PUBLIC>.
This fixes the rights statements logic to also accept such values.