### PR TITLE
 Fix behavior if publisher_uri is not available

### DIFF
--- a/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
@@ -409,6 +409,39 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, publisher, RDF.type, FOAF.Organization)
         assert self._triple(g, publisher, FOAF.name, extras['publisher_name'])
 
+    def test_publisher_org_no_uri(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'organization': {
+                'id': '',
+                'name': 'publisher1',
+                'title': 'Example Publisher from Org',
+            },
+            'extras': [
+                {'key': 'publisher_name', 'value': 'Example Publisher'},
+                {'key': 'publisher_email', 'value': 'publisher@example.com'},
+                {'key': 'publisher_url', 'value': 'http://example.com/publisher/home'},
+                {'key': 'publisher_type', 'value': 'http://purl.org/adms/publishertype/Company'},
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer()
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        publisher = self._triple(g, dataset_ref, DCT.publisher, None)[2]
+        assert publisher
+        assert isinstance(publisher, BNode)
+
+        assert self._triple(g, publisher, RDF.type, FOAF.Organization)
+        assert self._triple(g, publisher, FOAF.name, extras['publisher_name'])
+        assert self._triple(g, publisher, FOAF.mbox, extras['publisher_email'])
+        assert self._triple(g, publisher, FOAF.homepage, URIRef(extras['publisher_url']))
+        assert self._triple(g, publisher, DCT.type, URIRef(extras['publisher_type']))
+
     def test_temporal(self):
         dataset = {
             'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',

--- a/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/test_schemaorg_profile_serialize.py
@@ -130,6 +130,43 @@ class TestSchemaOrgProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, contact_point, SCHEMA.url, extras['publisher_url'])
         assert self._triple(g, contact_point, SCHEMA.contactType, 'customer service')
 
+    def test_publisher_no_uri(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'organization': {
+                'id': '',
+                'name': 'publisher1',
+                'title': 'Example Publisher from Org',
+            },
+            'extras': [
+                {'key': 'publisher_name', 'value': 'Example Publisher'},
+                {'key': 'publisher_email', 'value': 'publisher@example.com'},
+                {'key': 'publisher_url', 'value': 'http://example.com/publisher/home'},
+                {'key': 'publisher_type', 'value': 'http://purl.org/adms/publishertype/Company'},
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer(profiles=['schemaorg'])
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        publisher = self._triple(g, dataset_ref, SCHEMA.publisher, None)[2]
+        assert publisher
+        assert isinstance(publisher, BNode)
+        assert self._triple(g, publisher, RDF.type, SCHEMA.Organization)
+        assert self._triple(g, publisher, SCHEMA.name, extras['publisher_name'])
+
+        contact_point = self._triple(g, publisher, SCHEMA.contactPoint, None)[2]
+        assert contact_point
+        assert self._triple(g, contact_point, RDF.type, SCHEMA.ContactPoint)
+        assert self._triple(g, contact_point, SCHEMA.name, extras['publisher_name'])
+        assert self._triple(g, contact_point, SCHEMA.email, extras['publisher_email'])
+        assert self._triple(g, contact_point, SCHEMA.url, extras['publisher_url'])
+        assert self._triple(g, contact_point, SCHEMA.contactType, 'customer service')
+
     def test_publisher_org(self):
         dataset = {
             'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -241,18 +241,10 @@ def resource_uri(resource_dict):
     return uri
 
 
-def publisher_uri_from_dataset_dict(dataset_dict):
+def publisher_uri_organization_fallback(dataset_dict):
     '''
-    Returns an URI for a dataset's publisher
-
-    This will be used to uniquely reference the publisher on the RDF
-    serializations.
-
-    The value will be the first found of:
-
-        1. The value of the `publisher_uri` field
-        2. The value of an extra with key `publisher_uri`
-        3. `catalog_uri()` + '/organization/' + `organization id` field
+    Builds a fallback dataset URI of the form
+    `catalog_uri()` + '/organization/' + `organization id` field
 
     Check the documentation for `catalog_uri()` for the recommended ways of
     setting it.
@@ -260,19 +252,11 @@ def publisher_uri_from_dataset_dict(dataset_dict):
     Returns a string with the publisher URI, or None if no URI could be
     generated.
     '''
-
-    uri = dataset_dict.get('publisher_uri')
-    if not uri:
-        for extra in dataset_dict.get('extras', []):
-            if extra['key'] == 'publisher_uri':
-                uri = extra['value']
-                break
-    if not uri and dataset_dict.get('organization'):
-        uri = '{0}/organization/{1}'.format(catalog_uri().rstrip('/'),
+    if dataset_dict.get('organization'):
+        return '{0}/organization/{1}'.format(catalog_uri().rstrip('/'),
                                             dataset_dict['organization']['id'])
 
-    return uri
-
+    return None
 
 def dataset_id_from_resource(resource_dict):
     '''


### PR DESCRIPTION
If no URI for the publisher is available in the serialized RDF graph currently always the URL from the organization is used. This can lead to same URI values for different publisher names if there is a publisher name in the RDF graph. To avoid this we should not use the URL from the organization if there is a publisher name but no publisher URI in the serialized RDF graph.