### PR TITLE
Support CKAN 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: '3.6'
@@ -44,9 +44,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - name: adding github workspace as safe directory
-      run: git config --global --add safe.directory $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install requirements
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -26,7 +26,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:
@@ -44,6 +44,8 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
+    - name: adding github workspace as safe directory
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
     - uses: actions/checkout@v2
     - name: Install requirements
       run: |

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -11,7 +11,7 @@ from ckan import model
 from ckan import logic
 from ckan import plugins as p
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
-
+from ckanext.harvest.logic.schema import unicode_safe
 from ckanext.dcat import converters
 from ckanext.dcat.harvesters.base import DCATHarvester
 
@@ -263,7 +263,7 @@ class DCATJSONHarvester(DCATHarvester):
 
                 # We need to explicitly provide a package ID
                 package_dict['id'] = str(uuid.uuid4())
-                package_schema['id'] = [str]
+                package_schema['id'] = [unicode_safe]
 
                 # Save reference to the package on the object
                 harvest_object.package_id = package_dict['id']

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -14,11 +14,9 @@ import ckan.model as model
 import ckan.lib.plugins as lib_plugins
 
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
-
+from ckanext.harvest.logic.schema import unicode_safe
 from ckanext.dcat.harvesters.base import DCATHarvester
-
 from ckanext.dcat.processors import RDFParserException, RDFParser
-
 from ckanext.dcat.interfaces import IDCATRDFHarvester
 
 
@@ -379,7 +377,7 @@ class DCATRDFHarvester(DCATHarvester):
 
                 # We need to explicitly provide a package ID
                 dataset['id'] = str(uuid.uuid4())
-                package_schema['id'] = [str]
+                package_schema['id'] = [unicode_safe]
 
                 harvester_tmp_dict = {}
 

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -236,13 +236,6 @@ class RDFSerializer(RDFProcessor):
         Returns the reference to the dataset, which will be an rdflib URIRef.
         '''
 
-        uri_value = dataset_dict.get('uri')
-        if not uri_value:
-            for extra in dataset_dict.get('extras', []):
-                if extra['key'] == 'uri':
-                    uri_value = extra['value']
-                    break
-
         dataset_ref = URIRef(dataset_uri(dataset_dict))
 
         for profile_class in self._profiles:

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -20,8 +20,7 @@ from geomet import wkt, InvalidGeoJSONException
 from ckan.model.license import LicenseRegister
 from ckan.plugins import toolkit
 from ckan.lib.munge import munge_tag
-from ckan.lib.helpers import url_for
-
+from ckanext.dcat.urls import url_for
 from ckanext.dcat.utils import resource_uri, publisher_uri_organization_fallback, DCAT_EXPOSE_SUBCATALOGS, DCAT_CLEAN_TAGS
 
 DCT = Namespace("http://purl.org/dc/terms/")
@@ -459,6 +458,7 @@ class RDFProfile(object):
             if isinstance(obj, BNode) and self._object(obj, RDF.type) == DCT.RightsStatement:
                 result = self._object_value(obj, RDFS.label)
             elif isinstance(obj, Literal) or isinstance(obj, URIRef):
+                # unicode_safe not include Literal or URIRef
                 result = six.text_type(obj)
         return result
 
@@ -1443,9 +1443,9 @@ class SchemaOrgProfile(RDFProfile):
         self._add_date_triples_from_dict(dataset_dict, dataset_ref, items)
 
         # Dataset URL
-        dataset_url = url_for('dataset_read',
+        dataset_url = url_for('dataset.read',
                               id=dataset_dict['name'],
-                              qualified=True)
+                              _external=True)
         self.g.add((dataset_ref, SCHEMA.url, Literal(dataset_url)))
 
     def _catalog_graph(self, dataset_ref, dataset_dict):
@@ -1461,7 +1461,7 @@ class SchemaOrgProfile(RDFProfile):
             group_url = url_for(controller='group',
                                 action='read',
                                 id=group.get('id'),
-                                qualified=True)
+                                _external=True)
             about = BNode()
 
             self.g.add((about, RDF.type, SCHEMA.Thing))

--- a/ckanext/dcat/templates/home/index.html
+++ b/ckanext/dcat/templates/home/index.html
@@ -2,9 +2,9 @@
 {% block links %}
     {{ super() }}
     {% with endpoint=h.dcat_get_endpoint('catalog')  %}
-        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _format='n3', qualified=True) }}"/>
-        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _format='ttl', qualified=True) }}"/>
-        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _format='xml', qualified=True) }}"/>
-        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _format='jsonld', qualified=True) }}"/>
+        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _format='n3', _external=True) }}"/>
+        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _format='ttl', _external=True) }}"/>
+        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _format='xml', _external=True) }}"/>
+        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _format='jsonld', _external=True) }}"/>
     {% endwith %}
 {% endblock -%}

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -2,10 +2,10 @@
 {% block links %}
     {{ super() }}
     {% with endpoint=h.dcat_get_endpoint('dataset')  %}
-        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _id=pkg.id, _format='n3', qualified=True) }}"/>
-        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _id=pkg.id, _format='ttl', qualified=True) }}"/>
-        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _id=pkg.id, _format='xml', qualified=True) }}"/>
-        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _id=pkg.id, _format='jsonld', qualified=True) }}"/>
+        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _id=pkg.id, _format='n3', _external=True) }}"/>
+        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _id=pkg.id, _format='ttl', _external=True) }}"/>
+        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _id=pkg.id, _format='xml', _external=True) }}"/>
+        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _id=pkg.id, _format='jsonld', _external=True) }}"/>
     {% endwith %}
 {% endblock -%}
 {% block body_extras %}

--- a/ckanext/dcat/templates/package/search.html
+++ b/ckanext/dcat/templates/package/search.html
@@ -2,9 +2,9 @@
 {% block links %}
     {{ super() }}
     {% with endpoint=h.dcat_get_endpoint('catalog')  %}
-        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _format='n3', qualified=True) }}"/>
-        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _format='ttl', qualified=True) }}"/>
-        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _format='xml', qualified=True) }}"/>
-        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _format='jsonld', qualified=True) }}"/>
+        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _format='n3', _external=True) }}"/>
+        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _format='ttl', _external=True) }}"/>
+        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _format='xml', _external=True) }}"/>
+        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _format='jsonld', _external=True) }}"/>
     {% endwith %}
 {% endblock -%}

--- a/ckanext/dcat/tests/test_blueprints.py
+++ b/ckanext/dcat/tests/test_blueprints.py
@@ -11,12 +11,12 @@ import pytest
 from ckan import plugins as p
 
 from rdflib import Graph
-from ckantoolkit import url_for as core_url_for
 from ckantoolkit.tests import factories
 
 from ckanext.dcat.processors import RDFParser
 from ckanext.dcat.profiles import RDF, DCAT
 from ckanext.dcat.processors import HYDRA
+from ckanext.dcat.urls import url_for
 
 
 def _sort_query_params(url):
@@ -29,28 +29,6 @@ def _sort_query_params(url):
         (parts.scheme, parts.netloc, parts.path, parts.params,
          encoded_qs, parts.fragment)
     )
-
-
-def url_for(*args, **kwargs):
-
-    if not p.toolkit.check_ckan_version(min_version='2.9'):
-
-        external = kwargs.pop('_external', False)
-        if external is not None:
-            kwargs['qualified'] = external
-
-        if len(args) and args[0] == 'dcat.read_dataset':
-            return core_url_for('dcat_dataset', **kwargs)
-        elif len(args) and args[0] == 'dcat.read_catalog':
-            return core_url_for('dcat_catalog', **kwargs)
-        elif len(args) and args[0] == 'dataset.new':
-            return core_url_for(controller='package', action='new', **kwargs)
-        elif len(args) and args[0] == 'dataset.read':
-            return core_url_for(controller='package', action='read', **kwargs)
-
-
-    return core_url_for(*args, **kwargs)
-
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 class TestEndpoints():

--- a/ckanext/dcat/urls.py
+++ b/ckanext/dcat/urls.py
@@ -1,0 +1,23 @@
+import six
+from ckan.plugins import toolkit as tk
+from ckantoolkit import url_for as core_url_for
+
+
+def url_for(*args, **kwargs):
+
+    if not tk.check_ckan_version(min_version='2.9'):
+
+        external = kwargs.pop('_external', False)
+        if external is not None and 'qualified' not in kwargs:
+            kwargs['qualified'] = external
+
+        if len(args) and args[0] == 'dcat.read_dataset':
+            return core_url_for('dcat_dataset', **kwargs)
+        elif len(args) and args[0] == 'dcat.read_catalog':
+            return core_url_for('dcat_catalog', **kwargs)
+        elif len(args) and args[0] == 'dataset.new':
+            return core_url_for(controller='package', action='new', **kwargs)
+        elif len(args) and args[0] == 'dataset.read':
+            return core_url_for(controller='package', action='read', **kwargs)
+
+    return core_url_for(*args, **kwargs)


### PR DESCRIPTION
Adding support for CKAN 2.10.

Related to [CKAN#6787](https://github.com/ckan/ckan/issues/6787)

CKAN master + harvest + DCAT looks good

![image](https://user-images.githubusercontent.com/3237309/163252750-f12f94f0-23ef-4da7-9966-83e0265b5f34.png)

This extensions requires `ckanext-harvest` and [Harvest#496](https://github.com/ckan/ckanext-harvest/pull/496) to be merged
(I sent a PR to that PR to update it [here](https://github.com/salsadigitalauorg/ckanext-harvest/pull/1/files))

With those PR merged, locally, I get all tests ok

![image](https://user-images.githubusercontent.com/3237309/163453003-7e9783cd-3a81-4882-a046-01acc239f7cd.png)
