### PR TITLE
Use unicode_safe validator in schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 rdflib==4.2.1
 rdflib-jsonld==0.4.0
 geomet>=0.2.0
-ckantoolkit==0.0.3
+ckantoolkit>=0.0.7
 future>=0.18.2
 six


### PR DESCRIPTION
Make ckantoolkit version compatible with the ckanext-harvest,
which requires ckantoolkit>=0.0.7 that have a unicode_safe function.
From ckanext-harvest:
CKAN core no longer supports builtin functions as validators.
Requires ckantoolkit>=0.0.7 for CKAN 2.8.10 support