### PR TITLE
Upgrade RDFLib requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install requirements
+    - name: Install requirements (Python 3)
+      if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' && matrix.ckan-version != '2.9-py2'}}
       run: |
         pip install -r requirements.txt
+    - name: Install requirements (Python 2)
+      if: ${{ matrix.ckan-version == '2.7' || matrix.ckan-version == '2.8' || matrix.ckan-version == '2.9-py2'}}
+      run: |
+        pip install -r requirements-py2.txt
+    - name: Install requirements (common)
+      run: |
         pip install -r dev-requirements.txt
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,13 +49,14 @@ jobs:
       if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' && matrix.ckan-version != '2.9-py2'}}
       run: |
         pip install -r requirements.txt
+        pip install -r dev-requirements.txt
     - name: Install requirements (Python 2)
       if: ${{ matrix.ckan-version == '2.7' || matrix.ckan-version == '2.8' || matrix.ckan-version == '2.9-py2'}}
       run: |
         pip install -r requirements-py2.txt
+        pip install -r dev-requirements-py2.txt
     - name: Install requirements (common)
       run: |
-        pip install -r dev-requirements.txt
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ These are implemented internally using:
 
         (pyenv) $ pip install -r ckanext-dcat/requirements.txt
 
+    > **Note**
+    >
+    > If you are running on Python 2.7 or 3.6 please use `requirements-py2-py36.txt` instead
+
 4.  Enable the required plugins in your ini file:
 
         ckan.plugins = dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface structured_data

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1421,7 +1421,7 @@ class SchemaOrgProfile(RDFProfile):
             self.g.add((subject, predicate, _type(value)))
 
     def _bind_namespaces(self):
-        self.g.bind('schema', namespaces['schema'])
+        self.g.bind('schema', namespaces['schema'], replace=True)
 
     def _basic_fields_graph(self, dataset_ref, dataset_dict):
         items = [

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1421,7 +1421,7 @@ class SchemaOrgProfile(RDFProfile):
             self.g.add((subject, predicate, _type(value)))
 
     def _bind_namespaces(self):
-        self.g.bind('schema', namespaces['schema'], replace=True)
+        self.g.namespace_manager.bind('schema', namespaces['schema'], replace=True)
 
     def _basic_fields_graph(self, dataset_ref, dataset_dict):
         items = [

--- a/ckanext/dcat/tests/test_base_profile.py
+++ b/ckanext/dcat/tests/test_base_profile.py
@@ -269,7 +269,7 @@ class TestBaseRDFProfile(object):
 
         g = Graph()
 
-        g.parse(data=data)
+        g.parse(format='xml', data=data)
 
         p = RDFProfile(g)
 
@@ -307,7 +307,7 @@ class TestBaseRDFProfile(object):
 
         g = Graph()
 
-        g.parse(data=data)
+        g.parse(format='xml', data=data)
 
         p = RDFProfile(g)
 
@@ -339,7 +339,7 @@ class TestBaseRDFProfile(object):
 
         g = Graph()
 
-        g.parse(data=data)
+        g.parse(format='xml', data=data)
 
         p = RDFProfile(g)
 
@@ -366,7 +366,7 @@ class TestBaseRDFProfile(object):
 
         g = Graph()
 
-        g.parse(data=data)
+        g.parse(format='xml', data=data)
 
         p = RDFProfile(g)
 
@@ -396,7 +396,7 @@ class TestBaseRDFProfile(object):
 
         g = Graph()
 
-        g.parse(data=data)
+        g.parse(format='xml', data=data)
 
         p = RDFProfile(g)
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -4,10 +4,14 @@ from builtins import str
 from builtins import range
 from builtins import object
 from collections import defaultdict
+import re
 
 import pytest
 import responses
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 import ckan.plugins as p
 from ckantoolkit import config

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -691,6 +691,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_default_file_size(self, mock_save_gather_error):
         # prepare
+        self._add_responses_solr_passthru()
         harvester = DCATRDFHarvester()
         actual_file_size =  1024 * 1024 * 110
         allowed_file_size = 1024 * 1024 * 50
@@ -720,6 +721,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     def test_harvest_config_file_size(self, mock_save_gather_error):
         # prepare
         harvester = DCATRDFHarvester()
+        self._add_responses_solr_passthru()
         actual_file_size =  1024 * 1024 * 110
         allowed_file_size = 1024 * 1024 * 100
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -25,7 +25,7 @@ from ckanext.dcat.interfaces import IDCATRDFHarvester
 import ckanext.dcat.harvesters.rdf
 
 
-responses.add_passthru(config.get('solr_url', 'http://127.0.0.1:8983/solr'))
+
 
 
 # TODO move to ckanext-harvest
@@ -541,6 +541,13 @@ class FunctionalHarvestTest(object):
           dc:title "Example dataset 1" .
           '''
 
+    def _add_responses_solr_passthru(self):
+        responses.add_passthru(
+            re.compile(
+                config.get(
+                    'solr_url', 'http://127.0.0.1:8983/solr').rstrip('/') + "/\\w+"
+            )
+        )
 
     def _create_harvest_source(self, mock_url, **kwargs):
 
@@ -655,6 +662,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     @responses.activate
     def _test_harvest_create(self, url, content, content_type, **kwargs):
 
+        self._add_responses_solr_passthru()
+
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=content, content_type=content_type)
@@ -679,6 +688,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
     @responses.activate
     def test_harvest_create_rdf_pagination(self):
+
+        self._add_responses_solr_passthru()
 
         # Mock the GET requests needed to get the file
         responses.add(responses.GET, self.rdf_mock_url_pagination_1,
@@ -715,6 +726,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
     @responses.activate
     def test_harvest_create_rdf_pagination_same_content(self):
+
+        self._add_responses_solr_passthru()
 
         # Mock the GET requests needed to get the file. Two different URLs but
         # same content to mock a misconfigured server
@@ -775,6 +788,9 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
     @responses.activate
     def _test_harvest_update(self, url, content, content_type):
+
+        self._add_responses_solr_passthru()
+
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=content, content_type=content_type)
@@ -833,6 +849,9 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
     @responses.activate
     def _test_harvest_update_resources(self, url, content, content_type):
+
+        self._add_responses_solr_passthru()
+
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=content, content_type=content_type)
@@ -896,6 +915,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     @responses.activate
     def _test_harvest_delete(self, url, content, content_small, content_type):
 
+        self._add_responses_solr_passthru()
+
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=content, content_type=content_type)
@@ -942,6 +963,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     @responses.activate
     def _test_harvest_bad_format(self, url, bad_content, content_type):
 
+        self._add_responses_solr_passthru()
+
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=bad_content, content_type=content_type)
@@ -972,6 +995,9 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     @responses.activate
     @patch.object(ckanext.dcat.harvesters.rdf.RDFParser, 'datasets')
     def test_harvest_exception_in_profile(self, mock_datasets):
+
+        self._add_responses_solr_passthru()
+
         mock_datasets.side_effect = Exception
 
         # Mock the GET request to get the file
@@ -1003,6 +1029,8 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
     @responses.activate
     def test_harvest_create_duplicate_titles(self):
+
+        self._add_responses_solr_passthru()
 
         # Mock the GET request to get the file
         responses.add(responses.GET, self.rdf_mock_url_duplicates,
@@ -1053,6 +1081,8 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_before_download_null_url_stops_gather_stage(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
+
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1094,6 +1124,8 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
     @responses.activate
     def test_harvest_before_download_errors_get_stored(self, reset_calls_counter):
+
+        self._add_responses_solr_passthru()
 
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
@@ -1149,6 +1181,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_update_session_add_header(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1172,6 +1205,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_after_download_extension_point_gets_called(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1193,6 +1227,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_after_download_empty_content_stops_gather_stage(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1236,6 +1271,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_after_download_errors_get_stored(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1278,6 +1314,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_after_parsing_extension_point_gets_called(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1304,6 +1341,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_after_parsing_empty_content_stops_gather_stage(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
         plugin.after_parsing_mode = 'return.empty.rdf_parser'
@@ -1349,6 +1387,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_after_parsing_errors_get_stored(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
         plugin.after_parsing_mode = 'return.errors'
@@ -1392,6 +1431,7 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_import_extensions_point_gets_called(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_harvester')
         plugin = p.get_plugin('test_rdf_harvester')
 
@@ -1459,6 +1499,7 @@ class TestDCATHarvestFunctionalSetNull(FunctionalHarvestTest):
     @responses.activate
     def test_harvest_with_before_create_null(self, reset_calls_counter):
 
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_null_harvester')
         plugin = p.get_plugin('test_rdf_null_harvester')
 
@@ -1518,6 +1559,8 @@ class TestDCATHarvestFunctionalRaiseExcpetion(FunctionalHarvestTest):
 
     @responses.activate
     def test_harvest_with_before_create_raising_exception(self, reset_calls_counter):
+
+        self._add_responses_solr_passthru()
         reset_calls_counter('test_rdf_exception_harvester')
         plugin = p.get_plugin('test_rdf_exception_harvester')
 

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -104,6 +104,7 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
         **kwargs
     ):
 
+        self._add_responses_solr_passthru()
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=content, content_type=content_type)
@@ -160,6 +161,8 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
         '''Based on _test_harvest_update_resources'''
         url = self.json_mock_url
         content_type = self.json_content_type
+
+        self._add_responses_solr_passthru()
         # Mock the GET request to get the file
         responses.add(responses.GET, url,
                                body=content_first_harvest,

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -3,7 +3,10 @@ from builtins import object
 
 import responses
 import pytest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from ckantoolkit.tests import helpers
 

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -69,16 +69,16 @@ def test_dataset_show_without_format():
 
 # Pagination
 
-
+@pytest.mark.usefixtures("with_request_context")
 class TestPagination(object):
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
-    @pytest.mark.ckan_config('ckan.site_url', 'http://example.com')
+    @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
     @mock.patch('ckan.plugins.toolkit.request')
     def test_pagination(self, mock_request):
 
         mock_request.params = {}
-        mock_request.host_url = 'http://ckan.example.com'
+        mock_request.host_url = 'http://test.ckan.net'
         mock_request.path = ''
 
         # No page defined (defaults to 1)
@@ -94,10 +94,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com?page=1'
-        assert pagination['first'] == 'http://example.com?page=1'
-        assert pagination['last'] == 'http://example.com?page=2'
-        assert pagination['next'] == 'http://example.com?page=2'
+        assert pagination['current'] == 'http://test.ckan.net?page=1'
+        assert pagination['first'] == 'http://test.ckan.net?page=1'
+        assert pagination['last'] == 'http://test.ckan.net?page=2'
+        assert pagination['next'] == 'http://test.ckan.net?page=2'
         assert 'previous' not in pagination
 
         # Page 1
@@ -113,10 +113,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com?page=1'
-        assert pagination['first'] == 'http://example.com?page=1'
-        assert pagination['last'] == 'http://example.com?page=2'
-        assert pagination['next'] == 'http://example.com?page=2'
+        assert pagination['current'] == 'http://test.ckan.net?page=1'
+        assert pagination['first'] == 'http://test.ckan.net?page=1'
+        assert pagination['last'] == 'http://test.ckan.net?page=2'
+        assert pagination['next'] == 'http://test.ckan.net?page=2'
         assert 'previous' not in pagination
 
         # Page 2
@@ -133,10 +133,10 @@ class TestPagination(object):
         assert pagination['count'] == 12
 
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com?page=2'
-        assert pagination['first'] == 'http://example.com?page=1'
-        assert pagination['last'] == 'http://example.com?page=2'
-        assert pagination['previous'] == 'http://example.com?page=1'
+        assert pagination['current'] == 'http://test.ckan.net?page=2'
+        assert pagination['first'] == 'http://test.ckan.net?page=1'
+        assert pagination['last'] == 'http://test.ckan.net?page=2'
+        assert pagination['previous'] == 'http://test.ckan.net?page=1'
         assert 'next' not in pagination
 
         # Page 3
@@ -152,19 +152,19 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com?page=3'
-        assert pagination['first'] == 'http://example.com?page=1'
-        assert pagination['last'] == 'http://example.com?page=2'
-        assert pagination['previous'] == 'http://example.com?page=2'
+        assert pagination['current'] == 'http://test.ckan.net?page=3'
+        assert pagination['first'] == 'http://test.ckan.net?page=1'
+        assert pagination['last'] == 'http://test.ckan.net?page=2'
+        assert pagination['previous'] == 'http://test.ckan.net?page=2'
         assert 'next' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 100)
-    @pytest.mark.ckan_config('ckan.site_url', 'http://example.com')
+    @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
     @mock.patch('ckan.plugins.toolkit.request')
     def test_pagination_less_results_than_page_size(self, mock_request):
 
         mock_request.params = {}
-        mock_request.host_url = 'http://ckan.example.com'
+        mock_request.host_url = 'http://ckan.test.ckan.net'
         mock_request.path = ''
 
         # No page defined (defaults to 1)
@@ -180,19 +180,19 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com?page=1'
-        assert pagination['first'] == 'http://example.com?page=1'
-        assert pagination['last'] == 'http://example.com?page=1'
+        assert pagination['current'] == 'http://test.ckan.net?page=1'
+        assert pagination['first'] == 'http://test.ckan.net?page=1'
+        assert pagination['last'] == 'http://test.ckan.net?page=1'
         assert 'next' not in pagination
         assert 'previous' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
-    @pytest.mark.ckan_config('ckan.site_url', 'http://example.com')
+    @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
     @mock.patch('ckan.plugins.toolkit.request')
     def test_pagination_same_results_than_page_size(self, mock_request):
 
         mock_request.params = {}
-        mock_request.host_url = 'http://ckan.example.com'
+        mock_request.host_url = 'http://ckan.test.ckan.net'
         mock_request.path = ''
 
         # No page defined (defaults to 1)
@@ -209,19 +209,19 @@ class TestPagination(object):
         assert pagination['count'] == 10
 
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com?page=1'
-        assert pagination['first'] == 'http://example.com?page=1'
-        assert pagination['last'] == 'http://example.com?page=1'
+        assert pagination['current'] == 'http://test.ckan.net?page=1'
+        assert pagination['first'] == 'http://test.ckan.net?page=1'
+        assert pagination['last'] == 'http://test.ckan.net?page=1'
         assert 'next' not in pagination
         assert 'previous' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
-    @pytest.mark.ckan_config('ckan.site_url', 'http://example.com')
+    @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
     @mock.patch('ckan.plugins.toolkit.request')
     def test_pagination_keeps_only_supported_params(self, mock_request):
 
         mock_request.params = {'a': 1, 'b': 2, 'modified_since': '2018-03-22', 'profiles': 'schemaorg'}
-        mock_request.host_url = 'http://ckan.example.com'
+        mock_request.host_url = 'http://ckan.test.ckan.net'
         mock_request.path = '/feed/catalog.xml'
 
         # No page defined (defaults to 1)
@@ -237,19 +237,19 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1'
-        assert pagination['first'] == 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1'
-        assert pagination['last'] == 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2'
-        assert pagination['next'] == 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2'
+        assert pagination['current'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1'
+        assert pagination['first'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1'
+        assert pagination['last'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2'
+        assert pagination['next'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2'
         assert 'previous' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
-    @pytest.mark.ckan_config('ckanext.dcat.base_uri', 'http://example.com/data')
+    @pytest.mark.ckan_config('ckanext.dcat.base_uri', 'http://test.ckan.net/data')
     @mock.patch('ckan.plugins.toolkit.request')
     def test_pagination_with_dcat_base_uri(self, mock_request):
 
         mock_request.params = {}
-        mock_request.host_url = 'http://ckan.example.com'
+        mock_request.host_url = 'http://ckan.test.ckan.net'
         mock_request.path = '/feed/catalog.xml'
 
         # No page defined (defaults to 1)
@@ -265,10 +265,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://example.com/data/feed/catalog.xml?page=1'
-        assert pagination['first'] == 'http://example.com/data/feed/catalog.xml?page=1'
-        assert pagination['last'] == 'http://example.com/data/feed/catalog.xml?page=2'
-        assert pagination['next'] == 'http://example.com/data/feed/catalog.xml?page=2'
+        assert pagination['current'] == 'http://test.ckan.net/data/feed/catalog.xml?page=1'
+        assert pagination['first'] == 'http://test.ckan.net/data/feed/catalog.xml?page=1'
+        assert pagination['last'] == 'http://test.ckan.net/data/feed/catalog.xml?page=2'
+        assert pagination['next'] == 'http://test.ckan.net/data/feed/catalog.xml?page=2'
         assert 'previous' not in pagination
 
     def test_pagination_no_results_empty_dict(self):

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -1,7 +1,10 @@
 from builtins import range
 from builtins import object
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -74,12 +74,7 @@ class TestPagination(object):
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
     @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
-    @mock.patch('ckan.plugins.toolkit.request')
-    def test_pagination(self, mock_request):
-
-        mock_request.params = {}
-        mock_request.host_url = 'http://test.ckan.net'
-        mock_request.path = ''
+    def test_pagination(self):
 
         # No page defined (defaults to 1)
         query = {
@@ -94,10 +89,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net?page=1'
-        assert pagination['first'] == 'http://test.ckan.net?page=1'
-        assert pagination['last'] == 'http://test.ckan.net?page=2'
-        assert pagination['next'] == 'http://test.ckan.net?page=2'
+        assert pagination['current'].endswith('?page=1')
+        assert pagination['first'].endswith('?page=1')
+        assert pagination['last'].endswith('?page=2')
+        assert pagination['next'].endswith('?page=2')
         assert 'previous' not in pagination
 
         # Page 1
@@ -113,10 +108,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net?page=1'
-        assert pagination['first'] == 'http://test.ckan.net?page=1'
-        assert pagination['last'] == 'http://test.ckan.net?page=2'
-        assert pagination['next'] == 'http://test.ckan.net?page=2'
+        assert pagination['current'].endswith('?page=1')
+        assert pagination['first'].endswith('?page=1')
+        assert pagination['last'].endswith('?page=2')
+        assert pagination['next'].endswith('?page=2')
         assert 'previous' not in pagination
 
         # Page 2
@@ -133,10 +128,10 @@ class TestPagination(object):
         assert pagination['count'] == 12
 
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net?page=2'
-        assert pagination['first'] == 'http://test.ckan.net?page=1'
-        assert pagination['last'] == 'http://test.ckan.net?page=2'
-        assert pagination['previous'] == 'http://test.ckan.net?page=1'
+        assert pagination['current'].endswith('?page=2')
+        assert pagination['first'].endswith('?page=1')
+        assert pagination['last'].endswith('?page=2')
+        assert pagination['previous'].endswith('?page=1')
         assert 'next' not in pagination
 
         # Page 3
@@ -152,20 +147,15 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net?page=3'
-        assert pagination['first'] == 'http://test.ckan.net?page=1'
-        assert pagination['last'] == 'http://test.ckan.net?page=2'
-        assert pagination['previous'] == 'http://test.ckan.net?page=2'
+        assert pagination['current'].endswith('?page=3')
+        assert pagination['first'].endswith('?page=1')
+        assert pagination['last'].endswith('?page=2')
+        assert pagination['previous'].endswith('?page=2')
         assert 'next' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 100)
     @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
-    @mock.patch('ckan.plugins.toolkit.request')
-    def test_pagination_less_results_than_page_size(self, mock_request):
-
-        mock_request.params = {}
-        mock_request.host_url = 'http://ckan.test.ckan.net'
-        mock_request.path = ''
+    def test_pagination_less_results_than_page_size(self):
 
         # No page defined (defaults to 1)
         query = {
@@ -180,20 +170,15 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net?page=1'
-        assert pagination['first'] == 'http://test.ckan.net?page=1'
-        assert pagination['last'] == 'http://test.ckan.net?page=1'
+        assert pagination['current'].endswith('?page=1')
+        assert pagination['first'].endswith('?page=1')
+        assert pagination['last'].endswith('?page=1')
         assert 'next' not in pagination
         assert 'previous' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)
     @pytest.mark.ckan_config('ckan.site_url', 'http://test.ckan.net')
-    @mock.patch('ckan.plugins.toolkit.request')
-    def test_pagination_same_results_than_page_size(self, mock_request):
-
-        mock_request.params = {}
-        mock_request.host_url = 'http://ckan.test.ckan.net'
-        mock_request.path = ''
+    def test_pagination_same_results_than_page_size(self):
 
         # No page defined (defaults to 1)
         query = {
@@ -209,9 +194,9 @@ class TestPagination(object):
         assert pagination['count'] == 10
 
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net?page=1'
-        assert pagination['first'] == 'http://test.ckan.net?page=1'
-        assert pagination['last'] == 'http://test.ckan.net?page=1'
+        assert pagination['current'].endswith('?page=1')
+        assert pagination['first'].endswith('?page=1')
+        assert pagination['last'].endswith('?page=1')
         assert 'next' not in pagination
         assert 'previous' not in pagination
 
@@ -237,10 +222,10 @@ class TestPagination(object):
 
         assert pagination['count'] == 12
         assert pagination['items_per_page'] == config.get('ckanext.dcat.datasets_per_page')
-        assert pagination['current'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1'
-        assert pagination['first'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1'
-        assert pagination['last'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2'
-        assert pagination['next'] == 'http://test.ckan.net/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2'
+        assert pagination['current'].endswith('/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1')
+        assert pagination['first'].endswith('/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1')
+        assert pagination['last'].endswith('/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2')
+        assert pagination['next'].endswith('/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2')
         assert 'previous' not in pagination
 
     @pytest.mark.ckan_config('ckanext.dcat.datasets_per_page', 10)

--- a/dev-requirements-py2.txt
+++ b/dev-requirements-py2.txt
@@ -1,0 +1,4 @@
+responses==0.17.0
+mock
+pytest-ckan
+pytest-cov

--- a/dev-requirements-py2.txt
+++ b/dev-requirements-py2.txt
@@ -1,4 +1,4 @@
-responses==0.17.0
+responses==0.10.15
 mock
 pytest-ckan
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-responses==0.10.9
-mock==2.0.0
+responses==0.20.0
+mock
 pytest-ckan
 pytest-cov

--- a/requirements-py2-py36.txt
+++ b/requirements-py2-py36.txt
@@ -1,0 +1,1 @@
+requirements-py2.txt

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,5 +1,5 @@
-rdflib==4.2.1
-rdflib-jsonld==0.4.0
+rdflib==5.0.0
+rdflib-jsonld==0.5.0
 geomet>=0.2.0
 ckantoolkit>=0.0.7
 future>=0.18.2

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,0 +1,6 @@
+rdflib==4.2.1
+rdflib-jsonld==0.4.0
+geomet>=0.2.0
+ckantoolkit>=0.0.7
+future>=0.18.2
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-rdflib==4.2.1
-rdflib-jsonld==0.4.0
+rdflib==6.1.1
 geomet>=0.2.0
 ckantoolkit>=0.0.7
 future>=0.18.2


### PR DESCRIPTION
The current version of RDFlib won't work on Python 3.9 so we need to upgrade to RDFlib 6, which is not compatible with Python 2. The JSON-LD requirement has been integrated into the main rdflib package.

This adapts the tests so they can run across all RDFLib / Python / CKAN version :crossed_fingers: 