### PR TITLE
Change some fields from Literal to URIRefOrLiteral

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -61,19 +61,20 @@ class URIRefOrLiteral(object):
     Like CleanedURIRef, this is a factory class.
     '''
     def __new__(cls, value):
-        stripped_value = value.strip()
-        if (isinstance(value, basestring) and (stripped_value.startswith("http://")
-                                               or stripped_value.startswith("https://"))):
-            uri_obj = CleanedURIRef(value)
-            # although all invalid chars checked by rdflib should have been quoted, try to serialize
-            # the object. If it breaks, use Literal instead.
-            try:
+        try:
+            stripped_value = value.strip()
+            if (isinstance(value, basestring) and (stripped_value.startswith("http://")
+                                                or stripped_value.startswith("https://"))):
+                uri_obj = CleanedURIRef(value)
+                # although all invalid chars checked by rdflib should have been quoted, try to serialize
+                # the object. If it breaks, use Literal instead.
                 uri_obj.n3()
-            except Exception:
+                # URI is fine, return the object
+                return uri_obj
+            else:
                 return Literal(value)
-            # URI is fine, return the object
-            return uri_obj
-        else:
+        except Exception:
+            # In case something goes wrong: use Literal
             return Literal(value)
 
 
@@ -1060,11 +1061,11 @@ class EuropeanDCATAPProfile(RDFProfile):
             ('title', DCT.title, None, Literal),
             ('notes', DCT.description, None, Literal),
             ('url', DCAT.landingPage, None, URIRef),
-            ('identifier', DCT.identifier, ['guid', 'id'], Literal),
+            ('identifier', DCT.identifier, ['guid', 'id'], URIRefOrLiteral),
             ('version', OWL.versionInfo, ['dcat_version'], Literal),
             ('version_notes', ADMS.versionNotes, None, Literal),
             ('frequency', DCT.accrualPeriodicity, None, URIRefOrLiteral),
-            ('access_rights', DCT.accessRights, None, Literal),
+            ('access_rights', DCT.accessRights, None, URIRefOrLiteral),
             ('dcat_type', DCT.type, None, Literal),
             ('provenance', DCT.provenance, None, Literal),
         ]
@@ -1086,13 +1087,13 @@ class EuropeanDCATAPProfile(RDFProfile):
             ('language', DCT.language, None, URIRefOrLiteral),
             ('theme', DCAT.theme, None, URIRef),
             ('conforms_to', DCT.conformsTo, None, Literal),
-            ('alternate_identifier', ADMS.identifier, None, Literal),
+            ('alternate_identifier', ADMS.identifier, None, URIRefOrLiteral),
             ('documentation', FOAF.page, None, URIRefOrLiteral),
             ('related_resource', DCT.relation, None, URIRefOrLiteral),
             ('has_version', DCT.hasVersion, None, URIRefOrLiteral),
             ('is_version_of', DCT.isVersionOf, None, URIRefOrLiteral),
-            ('source', DCT.source, None, Literal),
-            ('sample', ADMS.sample, None, Literal),
+            ('source', DCT.source, None, URIRefOrLiteral),
+            ('sample', ADMS.sample, None, URIRefOrLiteral),
         ]
         self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
 

--- a/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_profile_serialize.py
@@ -104,7 +104,7 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
             'metadata_modified': '2015-06-26T15:21:09.075774',
             'tags': [{'name': 'Tag 1'}, {'name': 'Tag 2'}],
             'extras': [
-                {'key': 'alternate_identifier', 'value': '[\"xyz\", \"abc\"]'},
+                {'key': 'alternate_identifier', 'value': '[\"xyz\", \"abc\", \"https://data.some.org/catalog/datasets/a-id-1\"]'},
                 {'key': 'version_notes', 'value': 'This is a beta version'},
                 {'key': 'frequency', 'value': 'monthly'},
                 {'key': 'language', 'value': '[\"en\", \"http://publications.europa.eu/resource/authority/language/ITA\"]'},
@@ -117,8 +117,8 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
                 {'key': 'related_resource', 'value': '[\"http://dataset.info.org/related1\", \"http://dataset.info.org/related2\"]'},
                 {'key': 'has_version', 'value': '[\"https://data.some.org/catalog/datasets/derived-dataset-1\", \"https://data.some.org/catalog/datasets/derived-dataset-2\"]'},
                 {'key': 'is_version_of', 'value': '[\"https://data.some.org/catalog/datasets/original-dataset\"]'},
-                {'key': 'source', 'value': '[\"https://data.some.org/catalog/datasets/source-dataset-1\", \"https://data.some.org/catalog/datasets/source-dataset-2\"]'},
-                {'key': 'sample', 'value': '[\"https://data.some.org/catalog/datasets/9df8df51-63db-37a8-e044-0003ba9b0d98/sample\"]'},
+                {'key': 'source', 'value': '[\"https://data.some.org/catalog/datasets/source-dataset-1\", \"https://data.some.org/catalog/datasets/source-dataset-2\", \"test_source\"]'},
+                {'key': 'sample', 'value': '[\"https://data.some.org/catalog/datasets/9df8df51-63db-37a8-e044-0003ba9b0d98/sample\", \"test_sample\"]'},
             ]
         }
         extras = self._extras(dataset)
@@ -156,13 +156,13 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
             ('language', DCT.language, [Literal, URIRef]),
             ('theme', DCAT.theme, URIRef),
             ('conforms_to', DCT.conformsTo, Literal),
-            ('alternate_identifier', ADMS.identifier, Literal),
+            ('alternate_identifier', ADMS.identifier, [Literal, Literal, URIRef]),
             ('documentation', FOAF.page, URIRef),
             ('related_resource', DCT.relation, URIRef),
             ('has_version', DCT.hasVersion, URIRef),
             ('is_version_of', DCT.isVersionOf, URIRef),
-            ('source', DCT.source, Literal),
-            ('sample', ADMS.sample, Literal),
+            ('source', DCT.source, [URIRef, URIRef, Literal]),
+            ('sample', ADMS.sample, [URIRef, Literal]),
         ]:
             values = json.loads(extras[item[0]])
             assert len([t for t in g.triples((dataset_ref, item[1], None))]) == len(values)
@@ -190,6 +190,24 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         dataset_ref = s.graph_from_dataset(dataset)
 
         assert self._triple(g, dataset_ref, DCT.identifier, extras['identifier'])
+
+    def test_identifier_extra_uri(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'extras': [
+                {'key': 'identifier', 'value': 'https://data.some.org/catalog/datasets/idxxx'},
+                {'key': 'guid', 'value': 'guidyyy'},
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer()
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        assert self._triple(g, dataset_ref, DCT.identifier, URIRef(extras['identifier']))
 
     def test_identifier_guid(self):
         dataset = {
@@ -236,6 +254,41 @@ class TestEuroDCATAPProfileSerializeDataset(BaseSerializeTest):
         dataset_ref = s.graph_from_dataset(dataset)
 
         assert self._triple(g, dataset_ref, DCT.identifier, dataset['id'])
+
+    def test_alternate_identifier_uri(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'extras': [
+                {'key': 'alternate_identifier', 'value': 'https://data.some.org/catalog/datasets/alt-id'},
+            ]
+        }
+
+        extras = self._extras(dataset)
+
+        s = RDFSerializer()
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        assert self._triple(g, dataset_ref, ADMS.identifier, URIRef(extras['alternate_identifier']))
+
+    def test_access_rights_uri(self):
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'extras': [
+                {'key': 'access_rights', 'value': 'https://data.some.org/catalog/datasets/public'}
+            ]
+        }
+        extras = self._extras(dataset)
+
+        s = RDFSerializer()
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        assert self._triple(g, dataset_ref, DCT.accessRights, URIRef(extras['access_rights']))
 
     def test_contact_details_extras(self):
         dataset = {


### PR DESCRIPTION
We changed a few more types in the profile from Literal to URIRefOrLiteral since they could contain an URI.