### PR TITLE
Make HTTP-Response size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also offers other features related to Semantic Data like exposing the necessa
     - [URIs](#uris)
     - [Content negotiation](#content-negotiation)
 - [RDF DCAT harvester](#rdf-dcat-harvester)
+    - [Maximum file size](#maximum-file-size)
     - [Transitive harvesting](#transitive-harvesting)
     - [Extending the RDF harvester](#extending-the-rdf-harvester)
 - [JSON DCAT harvester](#json-dcat-harvester)
@@ -255,6 +256,12 @@ The harvester will look at the `content-type` HTTP header field to determine the
 
 *TODO*: configure profiles.
 
+### Maximum file size
+
+The default max size of the file (for each HTTP response) to harvest is actually 50 MB. The size can be customised by setting the configuration option `ckanext.dcat.max_file_size` to your CKAN configuration file.
+Here‘s an example of setting the max file size to 100 MB:
+
+`ckanext.dcat.max_file_size = 100`
 
 ### Transitive harvesting
 

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -8,6 +8,8 @@ import rdflib
 from ckan import plugins as p
 from ckan import model
 
+from ckantoolkit import config
+import ckan.plugins.toolkit as toolkit
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject
@@ -20,7 +22,7 @@ log = logging.getLogger(__name__)
 
 class DCATHarvester(HarvesterBase):
 
-    MAX_FILE_SIZE = 1024 * 1024 * 50  # 50 Mb
+    DEFAULT_MAX_FILE_SIZE_MB = 50
     CHUNK_SIZE = 1024
 
     force_import = False
@@ -71,11 +73,12 @@ class DCATHarvester(HarvesterBase):
                 did_get = True
             r.raise_for_status()
 
+            max_file_size = 1024 * 1024 * toolkit.asint(config.get('ckanext.dcat.max_file_size', self.DEFAULT_MAX_FILE_SIZE_MB))
             cl = r.headers.get('content-length')
-            if cl and int(cl) > self.MAX_FILE_SIZE:
+            if cl and int(cl) > max_file_size:
                 msg = '''Remote file is too big. Allowed
                     file size: {allowed}, Content-Length: {actual}.'''.format(
-                    allowed=self.MAX_FILE_SIZE, actual=cl)
+                    allowed=max_file_size, actual=cl)
                 self._save_gather_error(msg, harvest_job)
                 return None, None
 
@@ -89,7 +92,7 @@ class DCATHarvester(HarvesterBase):
 
                 length += len(chunk)
 
-                if length >= self.MAX_FILE_SIZE:
+                if length >= max_file_size:
                     self._save_gather_error('Remote file is too big.',
                                             harvest_job)
                     return None, None

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -5,6 +5,7 @@ from builtins import range
 from builtins import object
 from collections import defaultdict
 
+import six
 import pytest
 import responses
 from mock import patch
@@ -672,6 +673,61 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
         for result in results['results']:
             assert result['title'] in ('Example dataset 1',
                                        'Example dataset 2')
+
+    @patch('ckanext.dcat.harvesters.DCATRDFHarvester._save_gather_error')
+    @responses.activate
+    def test_harvest_default_file_size(self, mock_save_gather_error):
+        # prepare
+        harvester = DCATRDFHarvester()
+        actual_file_size =  1024 * 1024 * 110
+        allowed_file_size = 1024 * 1024 * 50
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well
+        responses.add(responses.HEAD, self.ttl_mock_url,
+                               status=200, content_type=self.ttl_content_type,
+                               adding_headers = {'content-length': six.text_type(actual_file_size)})
+
+        harvest_source = self._create_harvest_source(self.ttl_mock_url)
+        # Create new job for the source
+        harvest_job = self._create_harvest_job(harvest_source['id'])
+
+        # execute
+        harvester._get_content_and_type(self.ttl_mock_url, harvest_job, 1, self.ttl_content_type)
+
+        # verify
+        msg = '''Remote file is too big. Allowed
+                    file size: {allowed}, Content-Length: {actual}.'''.format(
+                    allowed=allowed_file_size, actual=actual_file_size)
+        mock_save_gather_error.assert_called_once_with(msg, harvest_job)
+
+    @patch('ckanext.dcat.harvesters.DCATRDFHarvester._save_gather_error')
+    @responses.activate
+    @pytest.mark.ckan_config('ckanext.dcat.max_file_size', 100)
+    def test_harvest_config_file_size(self, mock_save_gather_error):
+        # prepare
+        harvester = DCATRDFHarvester()
+        actual_file_size =  1024 * 1024 * 110
+        allowed_file_size = 1024 * 1024 * 100
+
+        # The harvester will try to do a HEAD request first so we need to mock
+        # this as well  , content_length=file_size
+        responses.add(responses.HEAD, self.ttl_mock_url,
+                               status=200, content_type=self.ttl_content_type,
+                               adding_headers = {'content-length': six.text_type(actual_file_size)})
+
+        harvest_source = self._create_harvest_source(self.ttl_mock_url)
+        # Create new job for the source
+        harvest_job = self._create_harvest_job(harvest_source['id'])
+
+        # execute
+        harvester._get_content_and_type(self.ttl_mock_url, harvest_job, 1, self.ttl_content_type)
+
+        # verify
+        msg = '''Remote file is too big. Allowed
+                    file size: {allowed}, Content-Length: {actual}.'''.format(
+                    allowed=allowed_file_size, actual=actual_file_size)
+        mock_save_gather_error.assert_called_once_with(msg, harvest_job)
 
     @responses.activate
     def test_harvest_create_rdf_pagination(self):


### PR DESCRIPTION
We have made the limit of the harvest file size configurable via the CKAN configuration. The default size remains 50 MB.