### PR TITLE
Increase harvester get content chunk size

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 class DCATHarvester(HarvesterBase):
 
     DEFAULT_MAX_FILE_SIZE_MB = 50
-    CHUNK_SIZE = 1024
+    CHUNK_SIZE = 1024 * 512
 
     force_import = False
 


### PR DESCRIPTION
We have some RDF endpoints which delivers a big dump file with thousands of datasets resulting in a large file of up to 100 MB. And we have noticed that getting the whole content takes a very long time and sometime even gets interrupted. The reason is the small chunk size of 1 KB. So we like to increase the chunk size up to 512 KB.