### PR TITLE
replace occurrences of `text/ttl` with `text/turtle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ RDF representations will be advertised using `<link rel="alternate">` tags on th
     <head>
 
         <link rel="alternate" type="application/rdf+xml" href="http://demo.ckan.org/dataset/34315559-2b08-44eb-a2e6-ebe9ce1a266b.rdf"/>
-        <link rel="alternate" type="text/ttl" href="http://demo.ckan.org/dataset/34315559-2b08-44eb-a2e6-ebe9ce1a266b.ttl"/>
+        <link rel="alternate" type="text/turtle" href="http://demo.ckan.org/dataset/34315559-2b08-44eb-a2e6-ebe9ce1a266b.ttl"/>
         <!-- ... -->
 
     </head>
@@ -167,7 +167,7 @@ RDF representations will be advertised using `<link rel="alternate">` tags on th
 
         <link rel="alternate" type="application/rdf+xml" href="http://demo.ckan.org/catalog.rdf"/>
         <link rel="alternate" type="application/rdf+xml" href="http://demo.ckan.org/catalog.xml"/>
-        <link rel="alternate" type="text/ttl" href="http://demo.ckan.org/catalog.ttl"/>
+        <link rel="alternate" type="text/turtle" href="http://demo.ckan.org/catalog.ttl"/>
         <!-- ... -->
 
     </head>

--- a/ckanext/dcat/templates/home/index.html
+++ b/ckanext/dcat/templates/home/index.html
@@ -3,7 +3,7 @@
     {{ super() }}
     {% with endpoint=h.dcat_get_endpoint('catalog')  %}
         <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _format='n3', _external=True) }}"/>
-        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _format='ttl', _external=True) }}"/>
+        <link rel="alternate" type="text/turtle" href="{{ h.url_for(endpoint, _format='ttl', _external=True) }}"/>
         <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _format='xml', _external=True) }}"/>
         <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _format='jsonld', _external=True) }}"/>
     {% endwith %}

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -3,7 +3,7 @@
     {{ super() }}
     {% with endpoint=h.dcat_get_endpoint('dataset')  %}
         <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _id=pkg.id, _format='n3', _external=True) }}"/>
-        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _id=pkg.id, _format='ttl', _external=True) }}"/>
+        <link rel="alternate" type="text/turtle" href="{{ h.url_for(endpoint, _id=pkg.id, _format='ttl', _external=True) }}"/>
         <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _id=pkg.id, _format='xml', _external=True) }}"/>
         <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _id=pkg.id, _format='jsonld', _external=True) }}"/>
     {% endwith %}

--- a/ckanext/dcat/templates/package/search.html
+++ b/ckanext/dcat/templates/package/search.html
@@ -3,7 +3,7 @@
     {{ super() }}
     {% with endpoint=h.dcat_get_endpoint('catalog')  %}
         <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _format='n3', _external=True) }}"/>
-        <link rel="alternate" type="text/ttl" href="{{ h.url_for(endpoint, _format='ttl', _external=True) }}"/>
+        <link rel="alternate" type="text/turtle" href="{{ h.url_for(endpoint, _format='ttl', _external=True) }}"/>
         <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _format='xml', _external=True) }}"/>
         <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _format='jsonld', _external=True) }}"/>
     {% endwith %}


### PR DESCRIPTION
Several templates and the README have the media type of the Turtle format set to `text/ttl` (in the `<link>` elements for alternative representations). This is wrong, it should be `text/turtle`, as defined in the Turtle specification: https://www.w3.org/TR/turtle/#h3_sec-mime

This PR changes all occurrences of `text/ttl` to `text/turtle`.