### PR TITLE
Adapt tests to changes in ckanext-harvest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.5.0...HEAD)
 
+* Fix tests to work with `ckanext-harvest >= 1.5.4`.
 
 ## [v1.5.0](https://github.com/ckan/ckanext-dcat/compare/v1.4.0...v1.5.0) - 2023-05-02
 

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -1047,7 +1047,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
         assert last_job_status['status'] == 'Finished'
         assert ('Error parsing the RDF file'
-                in last_job_status['gather_error_summary'][0][0])
+                in last_job_status['gather_error_summary'][0]['message'])
 
     @responses.activate
     @patch.object(ckanext.dcat.harvesters.rdf.RDFParser, 'datasets')
@@ -1082,7 +1082,7 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
         assert last_job_status['status'] == 'Finished'
         assert ('Error when processsing dataset'
-                in last_job_status['gather_error_summary'][0][0])
+                in last_job_status['gather_error_summary'][0]['message'])
 
     @responses.activate
     def test_harvest_create_duplicate_titles(self):
@@ -1219,8 +1219,8 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         last_job_status = harvest_source['status']['last_job']
 
-        assert 'Error 1' == last_job_status['gather_error_summary'][0][0]
-        assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
+        assert 'Error 1' == last_job_status['gather_error_summary'][0]['message']
+        assert 'Error 2' == last_job_status['gather_error_summary'][1]['message']
 
     def test_harvest_update_session_extension_point_gets_called(self, reset_calls_counter):
 
@@ -1365,8 +1365,8 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
         last_job_status = harvest_source['status']['last_job']
 
-        assert 'Error 1' == last_job_status['gather_error_summary'][0][0]
-        assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
+        assert 'Error 1' == last_job_status['gather_error_summary'][0]['message']
+        assert 'Error 2' == last_job_status['gather_error_summary'][1]['message']
 
     @responses.activate
     def test_harvest_after_parsing_extension_point_gets_called(self, reset_calls_counter):
@@ -1480,8 +1480,8 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
 
             last_job_status = harvest_source['status']['last_job']
 
-            assert 'Error 1' == last_job_status['gather_error_summary'][0][0]
-            assert 'Error 2' == last_job_status['gather_error_summary'][1][0]
+            assert 'Error 1' == last_job_status['gather_error_summary'][0]['message']
+            assert 'Error 2' == last_job_status['gather_error_summary'][1]['message']
         finally:
             plugin.after_parsing_mode = ''
 
@@ -1648,7 +1648,7 @@ class TestDCATHarvestFunctionalRaiseExcpetion(FunctionalHarvestTest):
         assert last_job_status['status'] == 'Finished'
 
         assert ('Error importing dataset'
-                in last_job_status['object_error_summary'][0][0])
+                in last_job_status['object_error_summary'][0]['message'])
 
         assert (
             last_job_status['stats'] ==


### PR DESCRIPTION
With the changes in `ckanext-harvest 1.5.4` (https://github.com/ckan/ckanext-harvest/pull/529) the tests for `ckanext-dcat` are now failing. However, the functionality for `ckanext-dcat` remains untouched.

We`ve adapted the tests to those changes.

This pull request so far only supports usage of `ckanext-harvest >= 1.5.4` and breaks the tests for older versions. Should they be supported as well or is this not required?