### PR TITLE
Add references to each of the parsed access services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## [Unreleased](https://github.com/ckan/ckanext-dcat/compare/v1.5.0...HEAD)
 
-* Fix tests to work with `ckanext-harvest >= 1.5.4`.
+* Fix tests to work with `ckanext-harvest >= 1.5.4`. (#250)
+* Add references for dcat:accessService to the `euro_dcat_ap_2` profile (#251)
 
 ## [v1.5.0](https://github.com/ckan/ckanext-dcat/compare/v1.4.0...v1.5.0) - 2023-05-02
 

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1574,6 +1574,11 @@ class EuropeanDCATAP2Profile(EuropeanDCATAPProfile):
                             access_service_dict['uri'] = (str(access_service)
                                     if isinstance(access_service, URIRef)
                                     else '')
+
+                            # Remember the (internal) access service reference for referencing in
+                            # further profiles, e.g. for adding more properties
+                            access_service_dict['access_service_ref'] = str(access_service)
+
                             access_service_list.append(access_service_dict)
 
                         if access_service_list:
@@ -1655,6 +1660,9 @@ class EuropeanDCATAP2Profile(EuropeanDCATAPProfile):
                         access_service_node = CleanedURIRef(access_service_uri)
                     else:
                         access_service_node = BNode()
+                        # Remember the (internal) access service reference for referencing in
+                        # further profiles
+                        access_service_dict['access_service_ref'] = str(access_service_node)
 
                     self.g.add((distribution, DCAT.accessService, access_service_node))
 
@@ -1678,6 +1686,9 @@ class EuropeanDCATAP2Profile(EuropeanDCATAPProfile):
                         ('serves_dataset', DCAT.servesDataset, None, URIRefOrLiteral),
                     ]
                     self._add_list_triples_from_dict(access_service_dict, access_service_node, items)
+
+                if access_service_list:
+                    resource_dict['access_services'] = json.dumps(access_service_list)
             except ValueError:
                 pass
 

--- a/ckanext/dcat/tests/test_euro_dcatap_2_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_2_profile_parse.py
@@ -523,8 +523,10 @@ class TestEuroDCATAP2ProfileParsing(BaseParseTest):
         access_services_list = json.loads(access_services)
         assert len(access_services_list) == 2
 
-        for access_service in expected_access_services:
-            assert access_service in access_services_list
+        for access_service in access_services_list:
+            assert access_service.get('access_service_ref')
+            access_service.pop('access_service_ref')
+            assert access_service in expected_access_services
 
 class TestEuroDCATAP2ProfileParsingSpatial(BaseParseTest):
 

--- a/ckanext/dcat/tests/test_euro_dcatap_2_profile_serialize.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_2_profile_serialize.py
@@ -460,6 +460,7 @@ class TestEuroDCATAP2ProfileSerializeDataset(BaseSerializeTest):
             access_service = self._get_dict_from_list(access_services, 'title',
                                                                 six.text_type(title_objects[0][2]))
             assert access_service
+            assert access_service.get('access_service_ref', None)
 
             # Simple values
             self._assert_simple_value(g, object[2], DCATAP.availability,
@@ -510,6 +511,36 @@ class TestEuroDCATAP2ProfileSerializeDataset(BaseSerializeTest):
 
         object_list = [t for t in g.triples((distribution, DCAT.accessService, None))]
         assert len(object_list) == 0
+
+    def test_access_services_absent(self):
+
+        resource = {
+            'id': 'c041c635-054f-4431-b647-f9186926d021',
+            'package_id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'Distribution name'
+        }
+
+        dataset = {
+            'id': '4b6fe9ca-dc77-4cec-92a4-55c6624a5bd6',
+            'name': 'test-dataset',
+            'title': 'Test DCAT dataset',
+            'resources': [
+                resource
+            ]
+        }
+
+        s = RDFSerializer(profiles=DCAT_AP_PROFILES)
+        g = s.g
+
+        dataset_ref = s.graph_from_dataset(dataset)
+
+        assert len([t for t in g.triples((dataset_ref, DCAT.distribution, None))]) == 1
+
+        distribution = self._triple(g, dataset_ref, DCAT.distribution, None)[2]
+
+        object_list = [t for t in g.triples((distribution, DCAT.accessService, None))]
+        assert len(object_list) == 0
+        assert 'access_services' not in dataset['resources'][0]
 
     def _assert_simple_value(self, graph, object, predicate, value):
         """


### PR DESCRIPTION
The references for `dcat:accessService` are missing in the profile `euro_dcat_ap_2`. They are required to enhance the `access_services` in further profiles by adding more fields.
