### PR TITLE
fix missing access service items when parsing dataset

### DIFF
--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1567,7 +1567,7 @@ class EuropeanDCATAP2Profile(EuropeanDCATAPProfile):
                                     ('serves_dataset', DCAT.servesDataset),
                                     ):
                                 values = self._object_value_list(access_service, predicate)
-                                if value:
+                                if values:
                                     access_service_dict[key] = values
 
                             # Access service URI (explicitly show the missing ones)


### PR DESCRIPTION
When parsing datasets with a dcat:DataService the "endpoint_url" and "serves_dataset" properties are never added to the resource_dict due to a mislabeled variable name

Fx. a dataset with the following DataService:
```
<dcat:DataService rdf:about="https://example.com/dataservice1">
  <dcterms:title xml:lang="sv">API exempel</dcterms:title>
  <dcat:keyword xml:lang="sv">bibliotek</dcat:keyword>
  <dcat:keyword xml:lang="en">library</dcat:keyword>
  <dcat:contactPoint rdf:resource="https://example.com/contactpoint1"/>
  <dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
  <dcterms:accessRights rdf:resource="http://publications.europa.eu/resource/authority/access-right/PUBLIC"/>
  <dcat:endpointURL rdf:resource="http://example.com/api"/>
  <dcat:endpointDescription rdf:resource="http://example.com/apidescription"/>
  <dcat:servesDataset rdf:resource="https://example.com/dataset1" />
</dcat:DataService>
```

will return the following output when requesting the .rdf representation of the dataset:
```
<dcat:DataService rdf:about="https://example.com/dataservice1">
  <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
  <dct:accessRights rdf:resource="http://publications.europa.eu/resource/authority/access-right/PUBLIC"/>
  <dct:title>API exempel</dct:title>
  <dcat:endpointDescription>http://example.com/apidescription</dcat:endpointDescription>
</dcat:DataService>
```