### PR TITLE
Don't try to render the DCAT endpoints if turned off by config

### DIFF
--- a/ckanext/dcat/blueprints.py
+++ b/ckanext/dcat/blueprints.py
@@ -22,7 +22,8 @@ def read_catalog(_format=None, package_type=None):
 def read_dataset(_id, _format=None, package_type=None):
     return utils.read_dataset_page(_id, _format)
 
-if toolkit.asbool(config.get(utils.ENABLE_RDF_ENDPOINTS_CONFIG, True)):
+
+if utils.endpoints_enabled():
 
     # requirements={'_format': 'xml|rdf|n3|ttl|jsonld'}
     dcat.add_url_rule(config.get('ckanext.dcat.catalog_endpoint',

--- a/ckanext/dcat/plugins/__init__.py
+++ b/ckanext/dcat/plugins/__init__.py
@@ -80,6 +80,7 @@ class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
         return {
             'helper_available': utils.helper_available,
             'dcat_get_endpoint': utils.get_endpoint,
+            'dcat_endpoints_enabled': utils.endpoints_enabled,
         }
 
     # IActions

--- a/ckanext/dcat/templates/package/read_base.html
+++ b/ckanext/dcat/templates/package/read_base.html
@@ -1,12 +1,16 @@
 {% ckan_extends %}
 {% block links %}
+
     {{ super() }}
-    {% with endpoint=h.dcat_get_endpoint('dataset')  %}
-        <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _id=pkg.id, _format='n3', _external=True) }}"/>
-        <link rel="alternate" type="text/turtle" href="{{ h.url_for(endpoint, _id=pkg.id, _format='ttl', _external=True) }}"/>
-        <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _id=pkg.id, _format='xml', _external=True) }}"/>
-        <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _id=pkg.id, _format='jsonld', _external=True) }}"/>
-    {% endwith %}
+
+    {% if h.dcat_endpoints_enabled() %}
+      {% with endpoint=h.dcat_get_endpoint('dataset')  %}
+          <link rel="alternate" type="text/n3" href="{{ h.url_for(endpoint, _id=pkg.id, _format='n3', _external=True) }}"/>
+          <link rel="alternate" type="text/turtle" href="{{ h.url_for(endpoint, _id=pkg.id, _format='ttl', _external=True) }}"/>
+          <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(endpoint, _id=pkg.id, _format='xml', _external=True) }}"/>
+          <link rel="alternate" type="application/ld+json" href="{{ h.url_for(endpoint, _id=pkg.id, _format='jsonld', _external=True) }}"/>
+      {% endwith %}
+    {% endif %}
 {% endblock -%}
 {% block body_extras %}
   {{ super() }}

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -452,5 +452,9 @@ def read_catalog_page(_format):
     return response
 
 
+def endpoints_enabled():
+    return toolkit.asbool(config.get(ENABLE_RDF_ENDPOINTS_CONFIG, True))
+
+
 def get_endpoint(_type='dataset'):
     return 'dcat.read_dataset' if _type == 'dataset' else 'dcat.read_catalog'


### PR DESCRIPTION
Fixes #230

The templates were always trying to create the endpoints URL, even if the routes were not registered in the blueprint because it was set to ckanext.dcat.enable_rdf_endpoints = False