### PR TITLE
Adapt tests to latest changes in ckanext-harvest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Setup extension
       run: |
         ckan -c test.ini db init
-        ckan -c test.ini harvester initdb
+        ckan -c test.ini db pending-migrations --apply
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.dcat --cov-report=xml --cov-append --disable-warnings ckanext/dcat/tests
     - name: Upload coverage report to codecov

--- a/ckanext/dcat/tests/conftest.py
+++ b/ckanext/dcat/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+import ckan.plugins as p
+
+@pytest.fixture
+def clean_db(reset_db, migrate_db_for):
+    reset_db()
+    if p.get_plugin('harvest'):
+        migrate_db_for('harvest')

--- a/ckanext/dcat/tests/test_harvester.py
+++ b/ckanext/dcat/tests/test_harvester.py
@@ -27,13 +27,6 @@ import ckanext.dcat.harvesters.rdf
 
 
 
-
-# TODO move to ckanext-harvest
-@pytest.fixture
-def harvest_setup():
-    harvest_model.setup()
-
-
 @pytest.fixture
 def clean_queues():
     queue.purge_queues()
@@ -624,7 +617,7 @@ class FunctionalHarvestTest(object):
         self._fetch_queue(num_objects)
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'clean_queues')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'clean_queues')
 @pytest.mark.ckan_config('ckan.plugins', 'dcat harvest dcat_rdf_harvester')
 class TestDCATHarvestFunctional(FunctionalHarvestTest):
 
@@ -1118,7 +1111,6 @@ class TestDCATHarvestFunctional(FunctionalHarvestTest):
     'with_plugins',
     'clean_db',
     'clean_index',
-    'harvest_setup',
     'clean_queues',
 )
 @pytest.mark.ckan_config('ckan.plugins', 'dcat harvest dcat_rdf_harvester test_rdf_harvester')
@@ -1547,7 +1539,6 @@ class TestDCATHarvestFunctionalExtensionPoints(FunctionalHarvestTest):
     'with_plugins',
     'clean_db',
     'clean_index',
-    'harvest_setup',
     'clean_queues',
 )
 @pytest.mark.ckan_config('ckan.plugins', 'dcat harvest dcat_rdf_harvester test_rdf_null_harvester')
@@ -1608,7 +1599,6 @@ class TestDCATHarvestFunctionalSetNull(FunctionalHarvestTest):
     'with_plugins',
     'clean_db',
     'clean_index',
-    'harvest_setup',
     'clean_queues',
 )
 @pytest.mark.ckan_config('ckan.plugins', 'dcat harvest dcat_rdf_harvester test_rdf_exception_harvester')

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -14,10 +14,10 @@ import ckan.tests.factories as factories
 
 from ckanext.dcat.harvesters._json import copy_across_resource_ids, DCATJSONHarvester
 
-from .test_harvester import FunctionalHarvestTest, harvest_setup, clean_queues
+from .test_harvester import FunctionalHarvestTest, clean_queues
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'clean_queues')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'clean_queues')
 @pytest.mark.ckan_config('ckan.plugins', 'dcat harvest dcat_json_harvester')
 class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
 
@@ -284,7 +284,7 @@ class TestCopyAcrossResourceIds(object):
         )
         assert harvested_dataset['resources'][0].get('id') == None
 
-@pytest.mark.usefixtures('clean_db', 'clean_index', 'harvest_setup', 'clean_queues')
+@pytest.mark.usefixtures('clean_db', 'clean_index', 'clean_queues')
 class TestImportStage(object):
 
     class MockHarvestObject(object):


### PR DESCRIPTION
The workflow tests are currently broken when run with the master version of `ckanext-harvest`. With [this commit](https://github.com/ckan/ckanext-harvest/commit/c2ef796022a30eea15ce6f586b9287a2aa0742e6) in `ckanext-harvest` the way of initializing the db has been changed. 

This PR updates the tests for `ckanext-dcat` to solve the issue.
But I`m not quite sure if this is an ideal solution. Could someone take a closer look at this?