### PR TITLE
DCAT HVD 2.2.0

### DIFF
--- a/ckanext/dcat/codelists/__init__.py
+++ b/ckanext/dcat/codelists/__init__.py
@@ -1,0 +1,8 @@
+
+from .extract import extract
+from pathlib import Path
+
+high_value_dataset_category = extract(Path(__file__).parent / 'high-value-dataset-category.rdf')
+
+
+__all__ = ['high_value_dataset_category']

--- a/ckanext/dcat/codelists/extract.py
+++ b/ckanext/dcat/codelists/extract.py
@@ -1,0 +1,116 @@
+'''
+Converts EU RDF descriptions of codelists to ckanext-scheming choices.
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_164e0bf5">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Meteorological</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Meteorología</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Meteoroloģijas datu kopas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data meteoroloġika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Meteorologische data</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Meteorologiska data</prefLabel>
+        ... 
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 3</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+to:
+
+ {
+    "label": {
+      "en": "Meteorological",
+      "ga": "Meit\u00e9areola\u00edoch",
+      "mt": "Data meteorolo\u0121ika"
+    },
+    "value": "http://data.europa.eu/bna/c_164e0bf5"
+  },
+
+
+These are suitable for inclusion in the schema.json.
+
+'''
+
+import rdflib
+import rdflib.parser
+
+from rdflib.namespace import Namespace, RDF, SKOS
+
+from pathlib import Path
+import xml
+import json
+from functools import lru_cache
+
+from ckan.plugins import toolkit
+
+import logging
+log = logging.getLogger(__name__)
+
+
+EUVOC = Namespace("http://publications.europa.eu/ontology/euvoc#")
+# filter out variants of languages, en_GB doesn't match en.
+LANGS = set(l.split('_')[0] for l in toolkit.aslist(toolkit.config.get('ckan.locales_offered', ['en'])))
+
+
+class Codelist:
+    def __init__(self, choices, scheme):
+        self.choices = choices
+        self.scheme = scheme
+        self.choices_map = {elt['value']:elt['label'] for elt in choices}
+        log.debug(LANGS)
+    def labels(self, val):
+        return self.choices_map.get(val, {})
+
+@lru_cache(None)
+def extract(f:Path):
+
+    g = rdflib.ConjunctiveGraph()
+    try:
+        g.parse(data=f.read_text(), format='xml')
+    # Apparently there is no single way of catching exceptions from all
+    # rdflib parsers at once, so if you use a new one and the parsing
+    # exceptions are not cached, add them here.
+    # PluginException indicates that an unknown format was passed.
+    except (SyntaxError, xml.sax.SAXParseException,
+            rdflib.plugin.PluginException, TypeError) as e:
+        raise Exception(e)
+
+    choices = {}
+
+    for subject in g.subjects(RDF.type, SKOS.Concept):
+        labels = {l.language: str(l) for l in g.objects(subject, SKOS.prefLabel) if l.language in LANGS }
+        try:
+            order = list(g.objects(subject, EUVOC.order))[0]
+        except KeyError:
+            order = str(subject)
+
+        choice = {"label": labels,
+                  "value": str(subject)}
+
+        choices[order] = choice
+
+    ordered_choices = [v for k,v in sorted(choices.items())]
+
+    scheme = None
+    for subject in g.subjects(RDF.type, SKOS.ConceptScheme):
+        scheme = str(subject)
+    
+    return Codelist(ordered_choices, scheme)
+
+
+def write_json():
+    for path in Path(__file__).parent.glob('*.rdf'):
+        data = extract(path)
+        dest = path.parent / (path.stem + '.json')
+        with open (dest, 'w') as f:
+            json.dump(data.choices, f, indent=2)
+        
+
+#print(json.dumps(ordered_choices, indent=2))
+    
+    
+    

--- a/ckanext/dcat/codelists/high-value-dataset-category.rdf
+++ b/ckanext/dcat/codelists/high-value-dataset-category.rdf
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/asd487ae75">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<issued xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-27</issued>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-07</modified>
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">High-value dataset categories</title>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">High-value dataset categories</prefLabel>
+	<versionInfo xmlns="http://www.w3.org/2002/07/owl#">1.0</versionInfo>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_164e0bf5">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="bg">Метеорологични данни</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="cs">Meteorologie</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="da">Meteorologiske data</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Meteorologie</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="el">Μετεωρολογικές πληροφορίες</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Meteorological</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Meteorología</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="et">Meteoroloogiateave</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fi">Säätiedot</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Météorologiques</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ga">Meitéareolaíoch</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hr">Meteorološki podatci</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hu">Meteorológiai adatok</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="it">Dati meteorologici</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lt">Meteorologiniai duomenys</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Meteoroloģijas datu kopas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data meteoroloġika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Meteorologische data</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pl">Dane meteorologiczne</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pt">Meteorológicas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ro">Domeniul meteorologic</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sk">Meteorológia</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sl">Meteorološki podatki</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Meteorologiska data</prefLabel>
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 3</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_a9135398">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="bg">Дружества и собственост на дружествата</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="cs">Společnosti a vlastnictví společností</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="da">Virksomheder og virksomhedsejerskab</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Unternehmen und Eigentümerschaft von Unternehmen</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="el">Εταιρείες και ιδιοκτησιακό καθεστώς εταιρειών</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Companies and company ownership</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Sociedades y propiedad de sociedades</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="et">Äriühingud ja äriühingu omandisuhted</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fi">Yritys- ja yritysten omistustiedot</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Entreprises et propriété d'entreprises</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ga">Cuideachtaí agus úinéireacht cuideachtaí</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hr">Trgovačka društva i vlasništvo nad trgovačkim društvima</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hu">Vállalati és vállalattulajdonosi adatok</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="it">Dati relativi alle imprese e alla proprietà delle imprese</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lt">Bendrovės ir bendrovių valdymas nuosavybės teise</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Uzņēmumi un uzņēmumu īpašumtiesības</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data dwar il-kumpanniji u l-proprjetà tal-kumpanniji</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Bedrijven en eigendom van bedrijven</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pl">Dane dotyczące przedsiębiorstw i ich własności</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pt">Empresas e propriedade de empresas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ro">Domeniul Societăți și structura de proprietate a societăților</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sk">Spoločnosti a vlastníctvo spoločností</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sl">Družbe in lastništvo družb</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Företag och företagsägande</prefLabel>
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 5</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_ac64a52d">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="bg">Геопространствени данни</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="cs">Geoprostorové údaje</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="da">Geospatiale data</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Georaum</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="el">Γεωχωρικές πληροφορίες</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Geospatial</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Geoespacial</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="et">Georuumilised andmed</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fi">Paikkatiedot</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Géospatiales</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ga">Geospásúil</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hr">Geoprostorni podatci</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hu">Térinformatikai adatok</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="it">Dati geospaziali</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lt">Geoerdviniai duomenys</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Ģeotelpisko datu kopas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data ġeospazjali</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Geospatiale data</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pl">Dane geoprzestrzenne</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pt">Geoespaciais</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ro">Domeniul geospațial</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sk">Geopriestorové údaje</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sl">Geoprostorski podatki</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Geospatiala data</prefLabel>
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 1</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_b79e35eb">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="bg">Мобилност</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="cs">Mobilita</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="da">Mobilitet</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Mobilität</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="el">Κινητικότητα</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Mobility</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Movilidad</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="et">Liikuvus</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fi">Liikkuvuustiedot</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Mobilité</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ga">Soghluaisteacht</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hr">Mobilnost</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hu">Mobilitási adatok</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="it">Dati relativi alla mobilità</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lt">Judumas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Mobilitāte</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data dwar il-mobbiltà</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Mobiliteit</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pl">Dane dotyczące mobilności</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pt">Mobilidade</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ro">Domeniul Mobilitate</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sk">Mobilita</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sl">Mobilnost</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Rörlighet</prefLabel>
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 6</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_dd313021">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="bg">Наблюдение на Земята и околната среда</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="cs">Země a životní prostředí</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="da">Jordobservation og miljø</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Erdbeobachtung und Umwelt</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="el">Γεωσκόπηση και περιβάλλον</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Earth observation and environment</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Observación de la Tierra y medio ambiente</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="et">Maa seire ja keskkond</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fi">Maan havainnointi ja ympäristö</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Observation de la terre et environnement</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ga">Faire na cruinne agus an comhshaol</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hr">Promatranje Zemlje i okoliš</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hu">Földmegfigyelési és környezeti adatok</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="it">Dati relativi all'osservazione della terra e all'ambiente</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lt">Žemės stebėjimas ir aplinka</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Zemes novērošana un vide</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data dwar l-osservazzjoni tad-dinja u l-ambjent</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Aardobservatie en milieu</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pl">Dane dotyczące obserwacji Ziemi i środowiska</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pt">Observação da Terra e do ambiente</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ro">Domeniul Observarea Pământului și mediu</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sk">Pozorovanie Zeme a životné prostredie</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sl">Opazovanje zemlje in okolje</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Jordobservation och miljö</prefLabel>
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 2</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://data.europa.eu/bna/c_e1da4e07">
+	<startDate xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-07-06</startDate>
+	<created xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-05</created>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-09-13</modified>
+	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="bg">Статистика</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="cs">Statistika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="da">Statistik</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Statistik</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="el">Στατιστικές</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">Statistics</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="es">Estadística</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="et">Statistika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fi">Tilastotiedot</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="fr">Statistiques</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ga">Staidreamh</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hr">Statistički podatci</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="hu">Statisztikák</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="it">Dati statistici</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lt">Statistika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="lv">Statistika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="mt">Data statistika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="nl">Statistiek</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pl">Dane statystyczne</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="pt">Estatísticas</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="ro">Domeniul statistic</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sk">Štatistika</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sl">Statistični podatki</prefLabel>
+	<prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="sv">Statistik</prefLabel>
+	<order xmlns="http://publications.europa.eu/ontology/euvoc#" rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</order>
+	<definition xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">data sets as described in Commission Implementing Regulation (EU) 2023/138 of 21 December 2022 laying down a list of specific high-value datasets and the arrangements for their publication and re-use, Annex, Section 4</definition>
+	<inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+	<topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/bna/asd487ae75"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/ckanext/dcat/profiles.py
+++ b/ckanext/dcat/profiles.py
@@ -1774,6 +1774,14 @@ class EuropeanDCATAP2Profile(EuropeanDCATAPProfile):
         super(EuropeanDCATAP2Profile, self).graph_from_catalog(catalog_dict, catalog_ref)
 
 
+class EuropeanDCATAPHVD220Profile(EuropeanDCATAP2Profile):
+    ''' Read only catalog output for the HVD Profile, that only includes HVD resources '''
+    def graph_from_resource(self, g, dataset_ref, resource_dict, resource_license_fallback, distribution=None):
+        if 'http://data.europa.eu/eli/reg_impl/2023/138/oj' in \
+           self._read_list_value(self._get_dataset_value(resource_dict, 'applicable_legislation')):
+            return super().graph_from_resource(g, dataset_ref, resource_dict, resource_license_fallback, distribution)
+
+
 class SchemaOrgProfile(RDFProfile):
     '''
     An RDF profile based on the schema.org Dataset

--- a/ckanext/dcat/tests/shaql/README.md
+++ b/ckanext/dcat/tests/shaql/README.md
@@ -1,0 +1,1 @@
+These directories have SHAQL shapes to validate the DCAT compliance.

--- a/ckanext/dcat/tests/shaql/hvd/LICENSE.md
+++ b/ckanext/dcat/tests/shaql/hvd/LICENSE.md
@@ -1,0 +1,5 @@
+This directory was retrieved from https://github.com/SEMICeu/DCAT-AP/
+
+Licence from Upstream:
+Copyright © 2023 European Union. All material in this repository (https://github.com/SEMICeu/DCAT-AP/) is published under the licence CC-BY 4.0, unless explicitly otherwise mentioned. 
+

--- a/ckanext/dcat/tests/shaql/hvd/README.md
+++ b/ckanext/dcat/tests/shaql/hvd/README.md
@@ -1,0 +1,4 @@
+https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/html/hvd-SHACL-base.ttl
+https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/html/hvd-SHACL-ranges.ttl
+https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd/html/hvd-SHACL-full.ttl
+

--- a/ckanext/dcat/tests/shaql/hvd/hvd-SHACL-base.ttl
+++ b/ckanext/dcat/tests/shaql/hvd/hvd-SHACL-base.ttl
@@ -1,0 +1,566 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix shacl: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd> rdfs:member <https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#LegalResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LicenceDocumentShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#RightsstatementShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#StandardShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LiteralShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ConceptShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CataloguedResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DocumentShape> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/387c76a64757677cc2b899f0c4a20803263a0449>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/65eafe0643a998b84fc2d253de401f9ad8355770>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/edc684c84677aa4924b66988491caddda1a1e68b>;
+  shacl:targetClass dcat:CatalogRecord .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/387c76a64757677cc2b899f0c4a20803263a0449> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:name "primary topic"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "The expected value for primary topic is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/65eafe0643a998b84fc2d253de401f9ad8355770> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:minCount 1;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for primary topic"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/edc684c84677aa4924b66988491caddda1a1e68b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:maxCount 1;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for primary topic"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/01d5c746936ff78bb5eb353a1b0e49303cb2fd31>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/34db0dabef6e2aa992eab790fc3e8d1e3f83bc12>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/e9a8f5414305eafd449b87a38bfe0c974341c9ac>;
+  shacl:targetClass dcat:Catalog .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/01d5c746936ff78bb5eb353a1b0e49303cb2fd31> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.dataset";
+  shacl:description "A Dataset that is part of the Catalogue."@en;
+  shacl:name "dataset"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:dataset;
+  <https://purl.eu/ns/shacl#message> "The expected value for dataset is a rdfs:Resource (URI or blank node)"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/34db0dabef6e2aa992eab790fc3e8d1e3f83bc12> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.record";
+  shacl:description "A Catalogue Record that is part of the Catalogue"@en;
+  shacl:name "record"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:record;
+  <https://purl.eu/ns/shacl#message> "The expected value for record is a rdfs:Resource (URI or blank node)"@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/e9a8f5414305eafd449b87a38bfe0c974341c9ac> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.service";
+  shacl:description "A site or end-point (Data Service) that is listed in the Catalogue."@en;
+  shacl:name "service"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:service;
+  <https://purl.eu/ns/shacl#message> "The expected value for service is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CataloguedResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dcat:Resource .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ConceptShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass skos:Concept .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/3bde2663aaca96d953765ac2e525ef64710bf4d6>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/60675e8175395481680e343172eea5fcd3f82cd4>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/63240e11f1eb66f636413d1dbb134f0ff9066a7c>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68dc6d1df6d91b2d33990e6db3c5af31b3d51de8>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/83ad7325cc6681e43e44550c269847065a95a14f>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/8521ebd386ec388c4cf09933c419e3fe7668f29d>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/998ce689a5bcc3e2764ff84a05255e34d91e8102>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9adf9f5890592909cf3e67021ae7ab4f895a7745>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9eaae476a881de13b9430537ace6e70da7327dbd>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/b4c4138f0581e7240ec4dd866004c56407b3705a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/ca2bd10c893237fa342edb75240b08731acda92f>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/d36065836a29f463546e269c25db7b95b879b3fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/eab49dbeb9d895c6e13fc1a939b8a3a7cde0b52b>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f30149ffb6ec9d00dd5866b052105729fa27d02a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f514dbc668e2c9c457d61f1f2721c7fbcb22cb59>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDELI>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDCategoryCV>;
+  shacl:targetClass dcat:DataService .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/3bde2663aaca96d953765ac2e525ef64710bf4d6> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointURL";
+  shacl:description "The root location or primary endpoint of the service (an IRI)."@en;
+  shacl:name "endpoint URL"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:endpointURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for endpoint URL is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/60675e8175395481680e343172eea5fcd3f82cd4> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The expected value for HVD category is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/63240e11f1eb66f636413d1dbb134f0ff9066a7c> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointdescription";
+  shacl:description "A description of the services available via the end-points, including their operations, parameters etc."@en;
+  shacl:name "endpoint description"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:endpointDescription;
+  <https://purl.eu/ns/shacl#message> "The expected value for endpoint description is a rdfs:Resource (URI or blank node)"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68dc6d1df6d91b2d33990e6db3c5af31b3d51de8> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for contact point"@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/83ad7325cc6681e43e44550c269847065a95a14f> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointURL";
+  shacl:description "The root location or primary endpoint of the service (an IRI)."@en;
+  shacl:minCount 1;
+  shacl:name "endpoint URL"@en;
+  shacl:path dcat:endpointURL;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for endpoint URL"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/8521ebd386ec388c4cf09933c419e3fe7668f29d> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "documentation"@en;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for documentation"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/998ce689a5bcc3e2764ff84a05255e34d91e8102> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:name "documentation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "The expected value for documentation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9adf9f5890592909cf3e67021ae7ab4f895a7745> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:name "contact point"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact point is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9eaae476a881de13b9430537ace6e70da7327dbd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:maxCount 1;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for licence"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/b4c4138f0581e7240ec4dd866004c56407b3705a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.rights";
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The expected value for rights is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/ca2bd10c893237fa342edb75240b08731acda92f> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:name "serves dataset"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "The expected value for serves dataset is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/eab49dbeb9d895c6e13fc1a939b8a3a7cde0b52b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:minCount 1;
+  shacl:name "serves dataset"@en;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for serves dataset"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f30149ffb6ec9d00dd5866b052105729fa27d02a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:name "licence"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The expected value for licence is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f514dbc668e2c9c457d61f1f2721c7fbcb22cb59> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:minCount 1;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for HVD category"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/08118c51bfc41b71d11f3a58e9410da74e6480e6>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2f39bbd821cac86ab81596cd47c8798f3f60f0b9>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/924bfd3702cf51f4a6bc11bd1b7e06790d5d2fbc>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9adf9f5890592909cf3e67021ae7ab4f895a7745>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9f9f581dcae4fbd1653141d8b35ba7f86b4cf740>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/d36065836a29f463546e269c25db7b95b879b3fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/f6f077451f13ccf5d721838425fcc37f6cebfe48>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDELI>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDCategoryCV>;
+  shacl:targetClass dcat:Dataset .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/08118c51bfc41b71d11f3a58e9410da74e6480e6> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.conformsto";
+  shacl:description "An implementing rule or other specification."@en;
+  shacl:name "conforms to"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The expected value for conforms to is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2f39bbd821cac86ab81596cd47c8798f3f60f0b9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "dataset distribution"@en;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for dataset distribution"@en .
+
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/924bfd3702cf51f4a6bc11bd1b7e06790d5d2fbc> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD Category"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The expected value for HVD Category is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9adf9f5890592909cf3e67021ae7ab4f895a7745> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Dataset."@en;
+  shacl:name "contact point"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact point is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9f9f581dcae4fbd1653141d8b35ba7f86b4cf740> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:minCount 1;
+  shacl:name "HVD Category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for HVD Category"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/f6f077451f13ccf5d721838425fcc37f6cebfe48> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:name "dataset distribution"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "The expected value for dataset distribution is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/23d4c038584493decec780192681ef61694bff7c>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/27b3b10cebe804356667d0cfca6f658b01f83fbb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/9eaae476a881de13b9430537ace6e70da7327dbd>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/a490981ff58636ec8601ca500e67bd9c575eaed9>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/b4c4138f0581e7240ec4dd866004c56407b3705a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/d36065836a29f463546e269c25db7b95b879b3fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/e0065293221c5851ec508ae96cd4ad03ffdedd19>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/f30149ffb6ec9d00dd5866b052105729fa27d02a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/HVDELI>;
+  shacl:targetClass dcat:Distribution .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/23d4c038584493decec780192681ef61694bff7c> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessservice";
+  shacl:description "A data service that gives access to the distribution of the dataset"@en;
+  shacl:name "access service"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:accessService;
+  <https://purl.eu/ns/shacl#message> "The expected value for access service is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/27b3b10cebe804356667d0cfca6f658b01f83fbb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.linkedschemas";
+  shacl:description "An established schema to which the described Distribution conforms."@en;
+  shacl:name "linked schemas"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The expected value for linked schemas is a rdfs:Resource (URI or blank node)"@en .
+
+
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/9eaae476a881de13b9430537ace6e70da7327dbd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:maxCount 1;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for licence"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/a490981ff58636ec8601ca500e67bd9c575eaed9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessURL";
+  shacl:description "A URL that gives access to a Distribution of the Dataset."@en;
+  shacl:name "access URL"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:accessURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for access URL is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/b4c4138f0581e7240ec4dd866004c56407b3705a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.rights";
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The expected value for rights is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/e0065293221c5851ec508ae96cd4ad03ffdedd19> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessURL";
+  shacl:description "A URL that gives access to a Distribution of the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "access URL"@en;
+  shacl:path dcat:accessURL;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for access URL"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/f30149ffb6ec9d00dd5866b052105729fa27d02a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:name "licence"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The expected value for licence is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DocumentShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass foaf:Document .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property  
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/9b6ccc41bb0ced6f6b8f28a86e120bd9d73b32fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/a736c4b01ea7557518c0c146f3e311947ce00ccc>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/af064e842c8e058505005f10ba6025ee57ad168b>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/df2e16526cd0f7cc796d3bb27ac1861737a35d91>;
+  shacl:targetClass vcard:Kind .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/9b6ccc41bb0ced6f6b8f28a86e120bd9d73b32fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.email";
+  shacl:description """A email address via which contact can be made."""@en;
+  shacl:name "email"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path vcard:hasEmail;
+  <https://purl.eu/ns/shacl#message> "The expected value for email is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/a736c4b01ea7557518c0c146f3e311947ce00ccc> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.contactpage";
+  shacl:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact. "@en;
+  shacl:name "contact page"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path vcard:hasURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact page is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/af064e842c8e058505005f10ba6025ee57ad168b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.contactpage";
+  shacl:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact. "@en;
+  shacl:maxCount 1;
+  shacl:name "contact page"@en;
+  shacl:path vcard:hasURL;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for contact page"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/df2e16526cd0f7cc796d3bb27ac1861737a35d91> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.email";
+  shacl:description """A email address via which contact can be made."""@en;
+  shacl:maxCount 1;
+  shacl:name "email"@en;
+  shacl:path vcard:hasEmail;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for email"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LegalResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass <http://data.europa.eu/eli/ontology#LegalResource> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LicenceDocumentShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:LicenseDocument .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LiteralShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass rdfs:Literal .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass rdfs:Resource .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#RightsstatementShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:RightsStatement .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#StandardShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:Standard .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/union> rdfs:seeAlso "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#Kind";
+  shacl:description """It is recommended to provide at least either an email or a contact form from e.g. a service desk. """@en;
+  shacl:or (
+		[
+  			shacl:path vcard:hasEmail;
+			shacl:minCount 1 ;
+		]
+		[
+  			shacl:path vcard:hasURL;
+			shacl:minCount 1 ;
+		]
+	) ; 
+  a shacl:NodeShape ;
+  shacl:targetClass vcard:Kind ;
+  shacl:severity shacl:Warning ;
+  <https://purl.eu/ns/shacl#message> "It is recommended to provide at least either an email or a contact form from e.g. a service desk. "@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/legalInformation> rdfs:seeAlso "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#c3";
+  shacl:description """It is mandatory to provide legal information."""@en;
+  shacl:or (
+		[
+  			shacl:path dc:license;
+			shacl:minCount 1 ;
+		]
+		[
+  			shacl:path dc:rights;
+			shacl:minCount 1 ;
+		]
+	) ; 
+  a shacl:NodeShape ;
+  shacl:targetClass dcat:Distribution;
+  <https://purl.eu/ns/shacl#message> "It is mandatory to provide legal information."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/legalInformation> rdfs:seeAlso "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#c3";
+  shacl:description """It is mandatory to provide legal information."""@en;
+  shacl:or (
+		[
+  			shacl:path dc:license;
+			shacl:minCount 1 ;
+		]
+		[
+  			shacl:path dc:rights;
+			shacl:minCount 1 ;
+		]
+	) ; 
+  a shacl:NodeShape ;
+  shacl:targetClass dcat:DataService;
+  <https://purl.eu/ns/shacl#message> "It is mandatory to provide legal information."@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#SHACL> 
+  rdf:type owl:Ontology ;
+  owl:imports <http://data.europa.eu/bna/asd487ae75>.
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> 
+    a shacl:NodeShape ;
+    rdfs:comment "HVD Category Restriction" ;
+    rdfs:label "HVD Category Restriction" ;
+    shacl:property [
+        shacl:hasValue <http://data.europa.eu/bna/asd487ae75> ;
+        shacl:minCount 1 ;
+        shacl:nodeKind shacl:IRI ;
+        shacl:path skos:inScheme
+    ] .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDCategoryCV> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDcategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  shacl:node <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> ;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDCategoryCV> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  shacl:node <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> ;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .

--- a/ckanext/dcat/tests/shaql/hvd/hvd-SHACL-full.ttl
+++ b/ckanext/dcat/tests/shaql/hvd/hvd-SHACL-full.ttl
@@ -1,0 +1,712 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix shacl: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd> rdfs:member <https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#LegalResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LicenceDocumentShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#RightsstatementShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#StandardShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LiteralShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ConceptShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CataloguedResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DocumentShape> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/387c76a64757677cc2b899f0c4a20803263a0449>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/65eafe0643a998b84fc2d253de401f9ad8355770>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/c65d45ed7195ead5f643ec8c8afd29c6dd9662bf>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/edc684c84677aa4924b66988491caddda1a1e68b>;
+  shacl:targetClass dcat:CatalogRecord .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/387c76a64757677cc2b899f0c4a20803263a0449> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:name "primary topic"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "The expected value for primary topic is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/65eafe0643a998b84fc2d253de401f9ad8355770> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:minCount 1;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for primary topic"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/c65d45ed7195ead5f643ec8c8afd29c6dd9662bf> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:class dcat:Resource;
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "The range of primary topic must be of type <http://www.w3.org/ns/dcat#Resource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/edc684c84677aa4924b66988491caddda1a1e68b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:maxCount 1;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for primary topic"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/01d5c746936ff78bb5eb353a1b0e49303cb2fd31>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/337cf55721093cc585693a5397601643d59a4c46>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/34db0dabef6e2aa992eab790fc3e8d1e3f83bc12>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/7b94c69361e00163d16d78016cd994668c7fccda>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/c26f8a3ac6445e9f36176f951acd9d235af5ffd9>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/e9a8f5414305eafd449b87a38bfe0c974341c9ac>;
+  shacl:targetClass dcat:Catalog .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/01d5c746936ff78bb5eb353a1b0e49303cb2fd31> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.dataset";
+  shacl:description "A Dataset that is part of the Catalogue."@en;
+  shacl:name "dataset"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:dataset;
+  <https://purl.eu/ns/shacl#message> "The expected value for dataset is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/337cf55721093cc585693a5397601643d59a4c46> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.record";
+  shacl:class dcat:CatalogRecord;
+  shacl:description "A Catalogue Record that is part of the Catalogue"@en;
+  shacl:name "record"@en;
+  shacl:path dcat:record;
+  <https://purl.eu/ns/shacl#message> "The range of record must be of type <http://www.w3.org/ns/dcat#CatalogRecord>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/34db0dabef6e2aa992eab790fc3e8d1e3f83bc12> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.record";
+  shacl:description "A Catalogue Record that is part of the Catalogue"@en;
+  shacl:name "record"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:record;
+  <https://purl.eu/ns/shacl#message> "The expected value for record is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/7b94c69361e00163d16d78016cd994668c7fccda> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.dataset";
+  shacl:class dcat:Dataset;
+  shacl:description "A Dataset that is part of the Catalogue."@en;
+  shacl:name "dataset"@en;
+  shacl:path dcat:dataset;
+  <https://purl.eu/ns/shacl#message> "The range of dataset must be of type <http://www.w3.org/ns/dcat#Dataset>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/c26f8a3ac6445e9f36176f951acd9d235af5ffd9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.service";
+  shacl:class dcat:DataService;
+  shacl:description "A site or end-point (Data Service) that is listed in the Catalogue."@en;
+  shacl:name "service"@en;
+  shacl:path dcat:service;
+  <https://purl.eu/ns/shacl#message> "The range of service must be of type <http://www.w3.org/ns/dcat#DataService>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/e9a8f5414305eafd449b87a38bfe0c974341c9ac> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.service";
+  shacl:description "A site or end-point (Data Service) that is listed in the Catalogue."@en;
+  shacl:name "service"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:service;
+  <https://purl.eu/ns/shacl#message> "The expected value for service is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CataloguedResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dcat:Resource .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ConceptShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass skos:Concept .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1a61f733fafb015548fe0e21203d559c9cb4d228>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1aeb85e10acb27fafc68a1bc04adb4860ecbea59>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/3bde2663aaca96d953765ac2e525ef64710bf4d6>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/60675e8175395481680e343172eea5fcd3f82cd4>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/63240e11f1eb66f636413d1dbb134f0ff9066a7c>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68388ec47b77212d80036e8a02e9956f5ba0e0f5>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68dc6d1df6d91b2d33990e6db3c5af31b3d51de8>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/83ad7325cc6681e43e44550c269847065a95a14f>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/8521ebd386ec388c4cf09933c419e3fe7668f29d>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/99435c17158fbaa12d1d955b8886d5bf935ab016>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/998ce689a5bcc3e2764ff84a05255e34d91e8102>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9adf9f5890592909cf3e67021ae7ab4f895a7745>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9eaae476a881de13b9430537ace6e70da7327dbd>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/b4c4138f0581e7240ec4dd866004c56407b3705a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/ca2bd10c893237fa342edb75240b08731acda92f>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/d36065836a29f463546e269c25db7b95b879b3fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/dbcf2adef675735c48b532392359af27af5e8b71>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/eab49dbeb9d895c6e13fc1a939b8a3a7cde0b52b>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f30149ffb6ec9d00dd5866b052105729fa27d02a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f514dbc668e2c9c457d61f1f2721c7fbcb22cb59>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDELI>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDCategoryCV>;
+  shacl:targetClass dcat:DataService .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1a61f733fafb015548fe0e21203d559c9cb4d228> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:class dcat:Dataset;
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:name "serves dataset"@en;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "The range of serves dataset must be of type <http://www.w3.org/ns/dcat#Dataset>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1aeb85e10acb27fafc68a1bc04adb4860ecbea59> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:class skos:Concept;
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/3bde2663aaca96d953765ac2e525ef64710bf4d6> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointURL";
+  shacl:description "The root location or primary endpoint of the service (an IRI)."@en;
+  shacl:name "endpoint URL"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:endpointURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for endpoint URL is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/60675e8175395481680e343172eea5fcd3f82cd4> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The expected value for HVD category is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/63240e11f1eb66f636413d1dbb134f0ff9066a7c> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointdescription";
+  shacl:description "A description of the services available via the end-points, including their operations, parameters etc."@en;
+  shacl:name "endpoint description"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:endpointDescription;
+  <https://purl.eu/ns/shacl#message> "The expected value for endpoint description is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68388ec47b77212d80036e8a02e9956f5ba0e0f5> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:class foaf:Document;
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:name "documentation"@en;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "The range of documentation must be of type <http://xmlns.com/foaf/0.1/Document>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68dc6d1df6d91b2d33990e6db3c5af31b3d51de8> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for contact point"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:class <http://data.europa.eu/eli/ontology#LegalResource>;
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The range of applicable legislation must be of type <http://data.europa.eu/eli/ontology#LegalResource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:class vcard:Kind;
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The range of contact point must be of type <http://www.w3.org/2006/vcard/ns#Kind>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/83ad7325cc6681e43e44550c269847065a95a14f> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointURL";
+  shacl:description "The root location or primary endpoint of the service (an IRI)."@en;
+  shacl:minCount 1;
+  shacl:name "endpoint URL"@en;
+  shacl:path dcat:endpointURL;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for endpoint URL"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/8521ebd386ec388c4cf09933c419e3fe7668f29d> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "documentation"@en;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for documentation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/99435c17158fbaa12d1d955b8886d5bf935ab016> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.rights";
+  shacl:class dc:RightsStatement;
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The range of rights must be of type <http://purl.org/dc/terms/RightsStatement>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/998ce689a5bcc3e2764ff84a05255e34d91e8102> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:name "documentation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "The expected value for documentation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9adf9f5890592909cf3e67021ae7ab4f895a7745> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:name "contact point"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact point is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9eaae476a881de13b9430537ace6e70da7327dbd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:maxCount 1;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for licence"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/b4c4138f0581e7240ec4dd866004c56407b3705a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.rights";
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The expected value for rights is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/ca2bd10c893237fa342edb75240b08731acda92f> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:name "serves dataset"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "The expected value for serves dataset is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/dbcf2adef675735c48b532392359af27af5e8b71> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:class dc:LicenseDocument;
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The range of licence must be of type <http://purl.org/dc/terms/LicenseDocument>."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/eab49dbeb9d895c6e13fc1a939b8a3a7cde0b52b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:minCount 1;
+  shacl:name "serves dataset"@en;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for serves dataset"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f30149ffb6ec9d00dd5866b052105729fa27d02a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:name "licence"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The expected value for licence is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f514dbc668e2c9c457d61f1f2721c7fbcb22cb59> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:minCount 1;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for HVD category"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/08118c51bfc41b71d11f3a58e9410da74e6480e6>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2ab9813b47309d4af98fdfe34189ea24baecc8cd>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2f39bbd821cac86ab81596cd47c8798f3f60f0b9>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/892bcf3c90199fdd741a47fc4559dc59d5a5b034>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/924bfd3702cf51f4a6bc11bd1b7e06790d5d2fbc>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9adf9f5890592909cf3e67021ae7ab4f895a7745>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9f9f581dcae4fbd1653141d8b35ba7f86b4cf740>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/c84f7330b9538a899ebb875c44dc23c9882e74ac>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/d36065836a29f463546e269c25db7b95b879b3fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/f6f077451f13ccf5d721838425fcc37f6cebfe48>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDELI>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDCategoryCV>;
+  shacl:targetClass dcat:Dataset .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/08118c51bfc41b71d11f3a58e9410da74e6480e6> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.conformsto";
+  shacl:description "An implementing rule or other specification."@en;
+  shacl:name "conforms to"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The expected value for conforms to is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2ab9813b47309d4af98fdfe34189ea24baecc8cd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:class dcat:Distribution;
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:name "dataset distribution"@en;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "The range of dataset distribution must be of type <http://www.w3.org/ns/dcat#Distribution>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2f39bbd821cac86ab81596cd47c8798f3f60f0b9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "dataset distribution"@en;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for dataset distribution"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:class <http://data.europa.eu/eli/ontology#LegalResource>;
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The range of applicable legislation must be of type <http://data.europa.eu/eli/ontology#LegalResource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.contactpoint";
+  shacl:class vcard:Kind;
+  shacl:description "Contact information that can be used for sending comments about the Dataset."@en;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The range of contact point must be of type <http://www.w3.org/2006/vcard/ns#Kind>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/892bcf3c90199fdd741a47fc4559dc59d5a5b034> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:class skos:Concept;
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD Category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The range of HVD Category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/924bfd3702cf51f4a6bc11bd1b7e06790d5d2fbc> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD Category"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The expected value for HVD Category is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9adf9f5890592909cf3e67021ae7ab4f895a7745> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Dataset."@en;
+  shacl:name "contact point"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact point is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9f9f581dcae4fbd1653141d8b35ba7f86b4cf740> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:minCount 1;
+  shacl:name "HVD Category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for HVD Category"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/c84f7330b9538a899ebb875c44dc23c9882e74ac> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.conformsto";
+  shacl:class dc:Standard;
+  shacl:description "An implementing rule or other specification."@en;
+  shacl:name "conforms to"@en;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The range of conforms to must be of type <http://purl.org/dc/terms/Standard>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/f6f077451f13ccf5d721838425fcc37f6cebfe48> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:name "dataset distribution"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "The expected value for dataset distribution is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/226b9cb0511ec6b8da045829e10d2676ddbb8375>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/23d4c038584493decec780192681ef61694bff7c>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/27b3b10cebe804356667d0cfca6f658b01f83fbb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/7434c99492683a2fb06dcdcf1f238671caf3d462>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/99435c17158fbaa12d1d955b8886d5bf935ab016>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/9eaae476a881de13b9430537ace6e70da7327dbd>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/a490981ff58636ec8601ca500e67bd9c575eaed9>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/b4c4138f0581e7240ec4dd866004c56407b3705a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/d36065836a29f463546e269c25db7b95b879b3fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/dbcf2adef675735c48b532392359af27af5e8b71>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/e0065293221c5851ec508ae96cd4ad03ffdedd19>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/f30149ffb6ec9d00dd5866b052105729fa27d02a>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/HVDELI>;
+  shacl:targetClass dcat:Distribution .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/226b9cb0511ec6b8da045829e10d2676ddbb8375> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.linkedschemas";
+  shacl:class dc:Standard;
+  shacl:description "An established schema to which the described Distribution conforms."@en;
+  shacl:name "linked schemas"@en;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The range of linked schemas must be of type <http://purl.org/dc/terms/Standard>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/23d4c038584493decec780192681ef61694bff7c> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessservice";
+  shacl:description "A data service that gives access to the distribution of the dataset"@en;
+  shacl:name "access service"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:accessService;
+  <https://purl.eu/ns/shacl#message> "The expected value for access service is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/27b3b10cebe804356667d0cfca6f658b01f83fbb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.linkedschemas";
+  shacl:description "An established schema to which the described Distribution conforms."@en;
+  shacl:name "linked schemas"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The expected value for linked schemas is a rdfs:Resource (URI or blank node)"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:class <http://data.europa.eu/eli/ontology#LegalResource>;
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The range of applicable legislation must be of type <http://data.europa.eu/eli/ontology#LegalResource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/7434c99492683a2fb06dcdcf1f238671caf3d462> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessservice";
+  shacl:class dcat:DataService;
+  shacl:description "A data service that gives access to the distribution of the dataset"@en;
+  shacl:name "access service"@en;
+  shacl:path dcat:accessService;
+  <https://purl.eu/ns/shacl#message> "The range of access service must be of type <http://www.w3.org/ns/dcat#DataService>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/99435c17158fbaa12d1d955b8886d5bf935ab016> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.rights";
+  shacl:class dc:RightsStatement;
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The range of rights must be of type <http://purl.org/dc/terms/RightsStatement>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/9eaae476a881de13b9430537ace6e70da7327dbd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:maxCount 1;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for licence"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/a490981ff58636ec8601ca500e67bd9c575eaed9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessURL";
+  shacl:description "A URL that gives access to a Distribution of the Dataset."@en;
+  shacl:name "access URL"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:accessURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for access URL is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/b4c4138f0581e7240ec4dd866004c56407b3705a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.rights";
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The expected value for rights is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/dbcf2adef675735c48b532392359af27af5e8b71> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:class dc:LicenseDocument;
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The range of licence must be of type <http://purl.org/dc/terms/LicenseDocument>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/e0065293221c5851ec508ae96cd4ad03ffdedd19> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessURL";
+  shacl:description "A URL that gives access to a Distribution of the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "access URL"@en;
+  shacl:path dcat:accessURL;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for access URL"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/f30149ffb6ec9d00dd5866b052105729fa27d02a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:name "licence"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The expected value for licence is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DocumentShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass foaf:Document .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property 
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/9b6ccc41bb0ced6f6b8f28a86e120bd9d73b32fb>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/a736c4b01ea7557518c0c146f3e311947ce00ccc>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/af064e842c8e058505005f10ba6025ee57ad168b>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/df2e16526cd0f7cc796d3bb27ac1861737a35d91>;
+  shacl:targetClass vcard:Kind .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/9b6ccc41bb0ced6f6b8f28a86e120bd9d73b32fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.email";
+  shacl:description """A email address via which contact can be made."""@en;
+  shacl:name "email"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path vcard:hasEmail;
+  <https://purl.eu/ns/shacl#message> "The expected value for email is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/a736c4b01ea7557518c0c146f3e311947ce00ccc> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.contactpage";
+  shacl:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact. "@en;
+  shacl:name "contact page"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path vcard:hasURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact page is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/af064e842c8e058505005f10ba6025ee57ad168b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.contactpage";
+  shacl:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact. "@en;
+  shacl:maxCount 1;
+  shacl:name "contact page"@en;
+  shacl:path vcard:hasURL;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for contact page"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/df2e16526cd0f7cc796d3bb27ac1861737a35d91> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.email";
+  shacl:description """A email address via which contact can be made."""@en;
+  shacl:maxCount 1;
+  shacl:name "email"@en;
+  shacl:path vcard:hasEmail;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for email"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LegalResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass <http://data.europa.eu/eli/ontology#LegalResource> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LicenceDocumentShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:LicenseDocument .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LiteralShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass rdfs:Literal .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass rdfs:Resource .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#RightsstatementShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:RightsStatement .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#StandardShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:Standard .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/union> rdfs:seeAlso "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#Kind";
+  shacl:description """It is recommended to provide at least either an email or a contact form from e.g. a service desk. """@en;
+  shacl:or (
+		[
+  			shacl:path vcard:hasEmail;
+			shacl:minCount 1 ;
+		]
+		[
+  			shacl:path vcard:hasURL;
+			shacl:minCount 1 ;
+		]
+	) ; 
+  a shacl:NodeShape ;
+  shacl:targetClass vcard:Kind ;
+  shacl:severity shacl:Warning ;
+  <https://purl.eu/ns/shacl#message> "It is recommended to provide at least either an email or a contact form from e.g. a service desk. "@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/legalInformation> rdfs:seeAlso "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#c3";
+  shacl:description """It is mandatory to provide legal information."""@en;
+  shacl:or (
+		[
+  			shacl:path dc:license;
+			shacl:minCount 1 ;
+		]
+		[
+  			shacl:path dc:rights;
+			shacl:minCount 1 ;
+		]
+	) ; 
+  a shacl:NodeShape ;
+  shacl:targetClass dcat:Distribution;
+  <https://purl.eu/ns/shacl#message> "It is mandatory to provide legal information."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/legalInformation> rdfs:seeAlso "https://semiceu.github.io/uri.semic.eu-generated/DCAT-AP/releases/2.2.0-hvd/#c3";
+  shacl:description """It is mandatory to provide legal information."""@en;
+  shacl:or (
+		[
+  			shacl:path dc:license;
+			shacl:minCount 1 ;
+		]
+		[
+  			shacl:path dc:rights;
+			shacl:minCount 1 ;
+		]
+	) ; 
+  a shacl:NodeShape ;
+  shacl:targetClass dcat:DataService;
+  <https://purl.eu/ns/shacl#message> "It is mandatory to provide legal information."@en .
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#SHACL> 
+  rdf:type owl:Ontology ;
+  owl:imports <http://data.europa.eu/bna/asd487ae75>.
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> 
+    a shacl:NodeShape ;
+    rdfs:comment "HVD Category Restriction" ;
+    rdfs:label "HVD Category Restriction" ;
+    shacl:property [
+        shacl:hasValue <http://data.europa.eu/bna/asd487ae75> ;
+        shacl:minCount 1 ;
+        shacl:nodeKind shacl:IRI ;
+        shacl:path skos:inScheme
+    ] .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDCategoryCV> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDcategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  shacl:node <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> ;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDCategoryCV> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  shacl:node <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> ;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .

--- a/ckanext/dcat/tests/shaql/hvd/hvd-SHACL-ranges.ttl
+++ b/ckanext/dcat/tests/shaql/hvd/hvd-SHACL-ranges.ttl
@@ -1,0 +1,618 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix shacl: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd> rdfs:member <https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#LegalResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LicenceDocumentShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#RightsstatementShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#StandardShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LiteralShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ConceptShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CataloguedResourceShape>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DocumentShape> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property 
+
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/c65d45ed7195ead5f643ec8c8afd29c6dd9662bf>;
+  shacl:targetClass dcat:CatalogRecord .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/387c76a64757677cc2b899f0c4a20803263a0449> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:name "primary topic"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "The expected value for primary topic is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/65eafe0643a998b84fc2d253de401f9ad8355770> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:minCount 1;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for primary topic"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/c65d45ed7195ead5f643ec8c8afd29c6dd9662bf> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:class dcat:Resource;
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "The range of primary topic must be of type <http://www.w3.org/ns/dcat#Resource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueRecordShape/edc684c84677aa4924b66988491caddda1a1e68b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#CatalogueRecord.primarytopic";
+  shacl:description "A link to the Dataset, Data service or Catalog described in the record."@en;
+  shacl:maxCount 1;
+  shacl:name "primary topic"@en;
+  shacl:path foaf:primaryTopic;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for primary topic"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property 
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/337cf55721093cc585693a5397601643d59a4c46>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/7b94c69361e00163d16d78016cd994668c7fccda>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/c26f8a3ac6445e9f36176f951acd9d235af5ffd9>;
+  shacl:targetClass dcat:Catalog .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/01d5c746936ff78bb5eb353a1b0e49303cb2fd31> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.dataset";
+  shacl:description "A Dataset that is part of the Catalogue."@en;
+  shacl:name "dataset"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:dataset;
+  <https://purl.eu/ns/shacl#message> "The expected value for dataset is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/337cf55721093cc585693a5397601643d59a4c46> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.record";
+  shacl:class dcat:CatalogRecord;
+  shacl:description "A Catalogue Record that is part of the Catalogue"@en;
+  shacl:name "record"@en;
+  shacl:path dcat:record;
+  <https://purl.eu/ns/shacl#message> "The range of record must be of type <http://www.w3.org/ns/dcat#CatalogRecord>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/34db0dabef6e2aa992eab790fc3e8d1e3f83bc12> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.record";
+  shacl:description "A Catalogue Record that is part of the Catalogue"@en;
+  shacl:name "record"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:record;
+  <https://purl.eu/ns/shacl#message> "The expected value for record is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/7b94c69361e00163d16d78016cd994668c7fccda> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.dataset";
+  shacl:class dcat:Dataset;
+  shacl:description "A Dataset that is part of the Catalogue."@en;
+  shacl:name "dataset"@en;
+  shacl:path dcat:dataset;
+  <https://purl.eu/ns/shacl#message> "The range of dataset must be of type <http://www.w3.org/ns/dcat#Dataset>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/c26f8a3ac6445e9f36176f951acd9d235af5ffd9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.service";
+  shacl:class dcat:DataService;
+  shacl:description "A site or end-point (Data Service) that is listed in the Catalogue."@en;
+  shacl:name "service"@en;
+  shacl:path dcat:service;
+  <https://purl.eu/ns/shacl#message> "The range of service must be of type <http://www.w3.org/ns/dcat#DataService>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CatalogueShape/e9a8f5414305eafd449b87a38bfe0c974341c9ac> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Catalogue.service";
+  shacl:description "A site or end-point (Data Service) that is listed in the Catalogue."@en;
+  shacl:name "service"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:service;
+  <https://purl.eu/ns/shacl#message> "The expected value for service is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#CataloguedResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dcat:Resource .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ConceptShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass skos:Concept .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property 
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1a61f733fafb015548fe0e21203d559c9cb4d228>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1aeb85e10acb27fafc68a1bc04adb4860ecbea59>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68388ec47b77212d80036e8a02e9956f5ba0e0f5>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/99435c17158fbaa12d1d955b8886d5bf935ab016>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/dbcf2adef675735c48b532392359af27af5e8b71>;
+  shacl:targetClass dcat:DataService .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1a61f733fafb015548fe0e21203d559c9cb4d228> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:class dcat:Dataset;
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:name "serves dataset"@en;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "The range of serves dataset must be of type <http://www.w3.org/ns/dcat#Dataset>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/1aeb85e10acb27fafc68a1bc04adb4860ecbea59> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:class skos:Concept;
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/3bde2663aaca96d953765ac2e525ef64710bf4d6> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointURL";
+  shacl:description "The root location or primary endpoint of the service (an IRI)."@en;
+  shacl:name "endpoint URL"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:endpointURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for endpoint URL is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/60675e8175395481680e343172eea5fcd3f82cd4> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The expected value for HVD category is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/63240e11f1eb66f636413d1dbb134f0ff9066a7c> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointdescription";
+  shacl:description "A description of the services available via the end-points, including their operations, parameters etc."@en;
+  shacl:name "endpoint description"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:endpointDescription;
+  <https://purl.eu/ns/shacl#message> "The expected value for endpoint description is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68388ec47b77212d80036e8a02e9956f5ba0e0f5> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:class foaf:Document;
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:name "documentation"@en;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "The range of documentation must be of type <http://xmlns.com/foaf/0.1/Document>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/68dc6d1df6d91b2d33990e6db3c5af31b3d51de8> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for contact point"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:class <http://data.europa.eu/eli/ontology#LegalResource>;
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The range of applicable legislation must be of type <http://data.europa.eu/eli/ontology#LegalResource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:class vcard:Kind;
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The range of contact point must be of type <http://www.w3.org/2006/vcard/ns#Kind>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/83ad7325cc6681e43e44550c269847065a95a14f> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.endpointURL";
+  shacl:description "The root location or primary endpoint of the service (an IRI)."@en;
+  shacl:minCount 1;
+  shacl:name "endpoint URL"@en;
+  shacl:path dcat:endpointURL;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for endpoint URL"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/8521ebd386ec388c4cf09933c419e3fe7668f29d> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "documentation"@en;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for documentation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/99435c17158fbaa12d1d955b8886d5bf935ab016> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.rights";
+  shacl:class dc:RightsStatement;
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The range of rights must be of type <http://purl.org/dc/terms/RightsStatement>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/998ce689a5bcc3e2764ff84a05255e34d91e8102> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.documentation";
+  shacl:description "A page that provides additional information about the Data Service."@en;
+  shacl:name "documentation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path foaf:Page;
+  <https://purl.eu/ns/shacl#message> "The expected value for documentation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9adf9f5890592909cf3e67021ae7ab4f895a7745> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Data Service."@en;
+  shacl:name "contact point"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact point is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/9eaae476a881de13b9430537ace6e70da7327dbd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:maxCount 1;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for licence"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/b4c4138f0581e7240ec4dd866004c56407b3705a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.rights";
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The expected value for rights is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/ca2bd10c893237fa342edb75240b08731acda92f> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:name "serves dataset"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "The expected value for serves dataset is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Data Service."@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/dbcf2adef675735c48b532392359af27af5e8b71> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:class dc:LicenseDocument;
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The range of licence must be of type <http://purl.org/dc/terms/LicenseDocument>."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/eab49dbeb9d895c6e13fc1a939b8a3a7cde0b52b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.servesdataset";
+  shacl:description "This property refers to a collection of data that this data service can distribute."@en;
+  shacl:minCount 1;
+  shacl:name "serves dataset"@en;
+  shacl:path dcat:servesDataset;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for serves dataset"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f30149ffb6ec9d00dd5866b052105729fa27d02a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.licence";
+  shacl:description "A licence under which the Data service is made available."@en;
+  shacl:name "licence"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The expected value for licence is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/f514dbc668e2c9c457d61f1f2721c7fbcb22cb59> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:minCount 1;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for HVD category"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property 
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2ab9813b47309d4af98fdfe34189ea24baecc8cd>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/892bcf3c90199fdd741a47fc4559dc59d5a5b034>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/c84f7330b9538a899ebb875c44dc23c9882e74ac>;
+  shacl:targetClass dcat:Dataset .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/08118c51bfc41b71d11f3a58e9410da74e6480e6> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.conformsto";
+  shacl:description "An implementing rule or other specification."@en;
+  shacl:name "conforms to"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The expected value for conforms to is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2ab9813b47309d4af98fdfe34189ea24baecc8cd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:class dcat:Distribution;
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:name "dataset distribution"@en;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "The range of dataset distribution must be of type <http://www.w3.org/ns/dcat#Distribution>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/2f39bbd821cac86ab81596cd47c8798f3f60f0b9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "dataset distribution"@en;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for dataset distribution"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:class <http://data.europa.eu/eli/ontology#LegalResource>;
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The range of applicable legislation must be of type <http://data.europa.eu/eli/ontology#LegalResource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/7b6713c1f4a52e964f5db57eabef294b6d04e90e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.contactpoint";
+  shacl:class vcard:Kind;
+  shacl:description "Contact information that can be used for sending comments about the Dataset."@en;
+  shacl:name "contact point"@en;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The range of contact point must be of type <http://www.w3.org/2006/vcard/ns#Kind>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/892bcf3c90199fdd741a47fc4559dc59d5a5b034> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:class skos:Concept;
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD Category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The range of HVD Category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/924bfd3702cf51f4a6bc11bd1b7e06790d5d2fbc> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD Category"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "The expected value for HVD Category is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9adf9f5890592909cf3e67021ae7ab4f895a7745> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.contactpoint";
+  shacl:description "Contact information that can be used for sending comments about the Dataset."@en;
+  shacl:name "contact point"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:contactPoint;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact point is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/9f9f581dcae4fbd1653141d8b35ba7f86b4cf740> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDCategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:minCount 1;
+  shacl:name "HVD Category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for HVD Category"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/c84f7330b9538a899ebb875c44dc23c9882e74ac> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.conformsto";
+  shacl:class dc:Standard;
+  shacl:description "An implementing rule or other specification."@en;
+  shacl:name "conforms to"@en;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The range of conforms to must be of type <http://purl.org/dc/terms/Standard>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/f6f077451f13ccf5d721838425fcc37f6cebfe48> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.datasetdistribution";
+  shacl:description "An available Distribution for the Dataset."@en;
+  shacl:name "dataset distribution"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:distribution;
+  <https://purl.eu/ns/shacl#message> "The expected value for dataset distribution is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:property 
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/226b9cb0511ec6b8da045829e10d2676ddbb8375>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/7434c99492683a2fb06dcdcf1f238671caf3d462>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/99435c17158fbaa12d1d955b8886d5bf935ab016>,
+    <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/dbcf2adef675735c48b532392359af27af5e8b71>;
+  shacl:targetClass dcat:Distribution .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/0a6f3bb11ed4ea12f852c78996b89c9a54ffc0fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:name "applicable legislation"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The expected value for applicable legislation is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/226b9cb0511ec6b8da045829e10d2676ddbb8375> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.linkedschemas";
+  shacl:class dc:Standard;
+  shacl:description "An established schema to which the described Distribution conforms."@en;
+  shacl:name "linked schemas"@en;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The range of linked schemas must be of type <http://purl.org/dc/terms/Standard>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/23d4c038584493decec780192681ef61694bff7c> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessservice";
+  shacl:description "A data service that gives access to the distribution of the dataset"@en;
+  shacl:name "access service"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:accessService;
+  <https://purl.eu/ns/shacl#message> "The expected value for access service is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/27b3b10cebe804356667d0cfca6f658b01f83fbb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.linkedschemas";
+  shacl:description "An established schema to which the described Distribution conforms."@en;
+  shacl:name "linked schemas"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:conformsTo;
+  <https://purl.eu/ns/shacl#message> "The expected value for linked schemas is a rdfs:Resource (URI or blank node)"@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/73465b7fbd7f991a08ddd1b766c2e46fa9dfc14e> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:class <http://data.europa.eu/eli/ontology#LegalResource>;
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "The range of applicable legislation must be of type <http://data.europa.eu/eli/ontology#LegalResource>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/7434c99492683a2fb06dcdcf1f238671caf3d462> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessservice";
+  shacl:class dcat:DataService;
+  shacl:description "A data service that gives access to the distribution of the dataset"@en;
+  shacl:name "access service"@en;
+  shacl:path dcat:accessService;
+  <https://purl.eu/ns/shacl#message> "The range of access service must be of type <http://www.w3.org/ns/dcat#DataService>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/99435c17158fbaa12d1d955b8886d5bf935ab016> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.rights";
+  shacl:class dc:RightsStatement;
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The range of rights must be of type <http://purl.org/dc/terms/RightsStatement>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/9eaae476a881de13b9430537ace6e70da7327dbd> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:maxCount 1;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for licence"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/a490981ff58636ec8601ca500e67bd9c575eaed9> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessURL";
+  shacl:description "A URL that gives access to a Distribution of the Dataset."@en;
+  shacl:name "access URL"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dcat:accessURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for access URL is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/b4c4138f0581e7240ec4dd866004c56407b3705a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.rights";
+  shacl:description "A statement that specifies rights associated with the Distribution."@en;
+  shacl:name "rights"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:rights;
+  <https://purl.eu/ns/shacl#message> "The expected value for rights is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/d36065836a29f463546e269c25db7b95b879b3fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The legislation that mandates the creation or management of the Distribution"@en;
+  shacl:minCount 1;
+  shacl:name "applicable legislation"@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation>;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for applicable legislation"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/dbcf2adef675735c48b532392359af27af5e8b71> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:class dc:LicenseDocument;
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:name "licence"@en;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The range of licence must be of type <http://purl.org/dc/terms/LicenseDocument>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/e0065293221c5851ec508ae96cd4ad03ffdedd19> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.accessURL";
+  shacl:description "A URL that gives access to a Distribution of the Dataset."@en;
+  shacl:minCount 1;
+  shacl:name "access URL"@en;
+  shacl:path dcat:accessURL;
+  <https://purl.eu/ns/shacl#message> "Minimally 1 values are expected for access URL"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/f30149ffb6ec9d00dd5866b052105729fa27d02a> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.licence";
+  shacl:description "A licence under which the Distribution is made available."@en;
+  shacl:name "licence"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path dc:license;
+  <https://purl.eu/ns/shacl#message> "The expected value for licence is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DocumentShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass foaf:Document .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass vcard:Kind .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/9b6ccc41bb0ced6f6b8f28a86e120bd9d73b32fb> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.email";
+  shacl:description """A email address via which contact can be made."""@en;
+  shacl:name "email"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path vcard:hasEmail;
+  <https://purl.eu/ns/shacl#message> "The expected value for email is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/a736c4b01ea7557518c0c146f3e311947ce00ccc> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.contactpage";
+  shacl:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact. "@en;
+  shacl:name "contact page"@en;
+  shacl:nodeKind shacl:BlankNodeOrIRI;
+  shacl:path vcard:hasURL;
+  <https://purl.eu/ns/shacl#message> "The expected value for contact page is a rdfs:Resource (URI or blank node)"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/af064e842c8e058505005f10ba6025ee57ad168b> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.contactpage";
+  shacl:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact. "@en;
+  shacl:maxCount 1;
+  shacl:name "contact page"@en;
+  shacl:path vcard:hasURL;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for contact page"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#KindShape/df2e16526cd0f7cc796d3bb27ac1861737a35d91> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Kind.email";
+  shacl:description """A email address via which contact can be made."""@en;
+  shacl:maxCount 1;
+  shacl:name "email"@en;
+  shacl:path vcard:hasEmail;
+  <https://purl.eu/ns/shacl#message> "Maximally 1 values allowed for email"@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LegalResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass <http://data.europa.eu/eli/ontology#LegalResource> .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LicenceDocumentShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:LicenseDocument .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#LiteralShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass rdfs:Literal .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#ResourceShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass rdfs:Resource .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#RightsstatementShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:RightsStatement .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#StandardShape> a shacl:NodeShape;
+  shacl:closed false;
+  shacl:targetClass dc:Standard .
+
+
+
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DistributionShape/HVDELI> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Distribution.applicablelegislation";
+  shacl:description "The applicable legislation must be set to the HVD IR ELI."@en;
+  shacl:path <http://data.europa.eu/r5r/applicableLegislation> ;
+  shacl:hasValue <http://data.europa.eu/eli/reg_impl/2023/138/oj> ;
+  <https://purl.eu/ns/shacl#message> "The applicable legislation must be set to the HVD IR ELI."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#SHACL> 
+  rdf:type owl:Ontology ;
+  owl:imports <http://data.europa.eu/bna/asd487ae75>.
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> 
+    a shacl:NodeShape ;
+    rdfs:comment "HVD Category Restriction" ;
+    rdfs:label "HVD Category Restriction" ;
+    shacl:property [
+        shacl:hasValue <http://data.europa.eu/bna/asd487ae75> ;
+        shacl:minCount 1 ;
+        shacl:nodeKind shacl:IRI ;
+        shacl:path skos:inScheme
+    ] .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DatasetShape/HVDCategoryCV> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#Dataset.HVDcategory";
+  shacl:description "The HVD category to which this Dataset belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  shacl:node <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> ;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .
+
+<https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#DataServiceShape/HVDCategoryCV> rdfs:seeAlso "https://semiceu.github.io//DCAT-AP/releases/2.2.0-hvd#DataService.HVDcategory";
+  shacl:description "The HVD category to which this Data Service belongs."@en;
+  shacl:name "HVD category"@en;
+  shacl:path <http://data.europa.eu/r5r/hvdCategory>;
+  shacl:node <https://semiceu.github.io/DCAT-AP/releases/2.2.0-hvd#HVDCategoryRestriction> ;
+  <https://purl.eu/ns/shacl#message> "The range of HVD category must be of type <http://www.w3.org/2004/02/skos/core#Concept>."@en .

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -431,11 +431,15 @@ def read_catalog_page(_format):
     if _profiles:
         _profiles = _profiles.split(',')
 
+    fq = toolkit.request.params.get('fq')
+    if _profiles and 'euro_dcat_ap_hvd_220' in _profiles:
+        fq = 'extras_applicable_legislation:"http://data.europa.eu/eli/reg_impl/2023/138/oj"'
+
     data_dict = {
         'page': toolkit.request.params.get('page'),
         'modified_since': toolkit.request.params.get('modified_since'),
         'q': toolkit.request.params.get('q'),
-        'fq': toolkit.request.params.get('fq'),
+        'fq': fq,
         'format': _format,
         'profiles': _profiles,
     }

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,13 @@ setup(
     install_requires=[
         # -*- Extra requirements: -*-
     ],
+    extras_require={
+        'dev': [
+            # ttll shaql validation of dcat schemas,
+            'pyshacl==0.19.1',  # version pinned for rdflib
+        ]
+    },
+
     entry_points='''
 
     [ckan.plugins]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     [ckan.rdf.profiles]
     euro_dcat_ap=ckanext.dcat.profiles:EuropeanDCATAPProfile
     euro_dcat_ap_2=ckanext.dcat.profiles:EuropeanDCATAP2Profile
+    euro_dcat_ap_hvd_220=ckanext.dcat.profiles:EuropeanDCATAPHVD220Profile
     schemaorg=ckanext.dcat.profiles:SchemaOrgProfile
 
     [babel.extractors]


### PR DESCRIPTION
Draft version of HVD 2.2.0 compliance

1) Adds support for codelists as a concept, and uses them for the HVD Category
2) Uses appropriate rdf typing to pass the shaql validation.
3) Provides a read-only profile to provide a HVD only catalog at `{base url}/catalog.ttl?profiles=euro_dcat_ap_hvd_220`
4) Extracts resource_to_graph into overridable methods.

Todo:
* [ ] Shaql validation in automatic testing