### PR TITLE
Parse dcat:spatialResolutionInMeters as float

### DIFF
--- a/ckanext/dcat/profiles/base.py
+++ b/ckanext/dcat/profiles/base.py
@@ -230,13 +230,31 @@ class RDFProfile(object):
 
         Both subject and predicate must be rdflib URIRef or BNode objects
 
-        If the value can not be parsed as intger, returns an empty list
+        If the value can not be parsed as integer, returns an empty list
         """
         object_values = []
         for object in self.g.objects(subject, predicate):
             if object:
                 try:
                     object_values.append(int(float(object)))
+                except ValueError:
+                    pass
+        return object_values
+
+    def _object_value_float_list(self, subject, predicate):
+        """
+        Given a subject and a predicate, returns the value of the object as a
+        list of floats
+
+        Both subject and predicate must be rdflib URIRef or BNode objects
+
+        If the value can not be parsed as a float, returns an empty list
+        """
+        object_values = []
+        for object in self.g.objects(subject, predicate):
+            if object:
+                try:
+                    object_values.append(float(object))
                 except ValueError:
                     pass
         return object_values

--- a/ckanext/dcat/profiles/euro_dcat_ap_2.py
+++ b/ckanext/dcat/profiles/euro_dcat_ap_2.py
@@ -54,7 +54,7 @@ class EuropeanDCATAP2Profile(EuropeanDCATAPProfile):
             self._add_spatial_to_dict(dataset_dict, key, spatial)
 
         # Spatial resolution in meters
-        spatial_resolution_in_meters = self._object_value_int_list(
+        spatial_resolution_in_meters = self._object_value_float_list(
             dataset_ref, DCAT.spatialResolutionInMeters
         )
         if spatial_resolution_in_meters:

--- a/ckanext/dcat/tests/test_euro_dcatap_2_profile_parse.py
+++ b/ckanext/dcat/tests/test_euro_dcatap_2_profile_parse.py
@@ -353,7 +353,7 @@ class TestEuroDCATAP2ProfileParsing(BaseParseTest):
         dataset = URIRef('http://example.org/datasets/1')
         g.add((dataset, RDF.type, DCAT.Dataset))
 
-        spatial_resolution_in_meters = 30
+        spatial_resolution_in_meters = 30.5
         g.add((dataset, DCAT.spatialResolutionInMeters, Literal(spatial_resolution_in_meters, datatype=XSD.decimal)))
 
         spatial_resolution_in_meters_2 = 20
@@ -368,9 +368,7 @@ class TestEuroDCATAP2ProfileParsing(BaseParseTest):
         extras = self._extras(datasets[0])
 
         spatial_resolution_list = json.loads(extras['spatial_resolution_in_meters'])
-        assert len(spatial_resolution_list) == 2
-        assert  spatial_resolution_in_meters in spatial_resolution_list
-        assert  spatial_resolution_in_meters_2 in spatial_resolution_list
+        assert sorted(spatial_resolution_list) == [20.0, 30.5]
 
     def test_isreferencedby_multiple(self):
         g = Graph()


### PR DESCRIPTION
According to the spec this should be typed as an xsd:Decimal, but we are parsing it as int:

https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_spatial_resolution

WDYT @seitenbau-govdata ?

This allows to retrieve the correct values for decimal numbers (eg `1.5` instead of `1`). This changes slightly the values returned for integers (eg `1` to `1.0`) but as this function is only currently used in this property I think it's safe to introduce the change.