### PR TITLE
feat: add has_version to default schema

### DIFF
--- a/ckanext/dcat/schemas/dcat_ap_full.yaml
+++ b/ckanext/dcat/schemas/dcat_ap_full.yaml
@@ -313,6 +313,13 @@ resource_fields:
   label: License
   help_text: License in which the resource is made available. If not provided will be inherited from the dataset.
 
+- field_name: has_version
+  label: Has version
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_inline: true
+  help_text: This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.
+
   # Note: this falls back to the standard resource url field
 - field_name: access_url
   label: Access URL


### PR DESCRIPTION
Missing has_version in full default example schema 