### PR TITLE
fix: Move has version from distribution to dataset

### DIFF
--- a/ckanext/dcat/schemas/dcat_ap_full.yaml
+++ b/ckanext/dcat/schemas/dcat_ap_full.yaml
@@ -258,6 +258,13 @@ dataset_fields:
   validators: ignore_missing scheming_multiple_text
   help_text: The legislation that mandates the creation or management of the dataset.
 
+- field_name: has_version
+  label: Has version
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_inline: true
+  help_text: This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.
+
 #- field_name: hvd_category
 #  label: HVD Category
 #  preset: multiple_text
@@ -347,13 +354,6 @@ resource_fields:
 - field_name: license
   label: License
   help_text: License in which the resource is made available. If not provided will be inherited from the dataset.
-
-- field_name: has_version
-  label: Has version
-  preset: multiple_text
-  validators: ignore_missing scheming_multiple_text
-  help_inline: true
-  help_text: This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.
 
   # Note: this falls back to the standard resource url field
 - field_name: access_url


### PR DESCRIPTION
This pull request corrects the placement of the dcat:hasVersion property in our DCAT implementation. Previously, the property was mistakenly defined under Distribution instead of Dataset. This update ensures compliance with the DCAT specification by associating dcat:hasVersion with Dataset.

I must admit, this was my mistake @amercader 