### PR TITLE
Update tests for changes in date parsing in new rdflib versions

### DIFF
--- a/ckanext/dcat/profiles/base.py
+++ b/ckanext/dcat/profiles/base.py
@@ -433,9 +433,6 @@ class RDFProfile(object):
         It checks for time intervals defined with DCAT, W3C Time hasBeginning & hasEnd
         and schema.org startDate & endDate.
 
-        Note that partial dates will be expanded to the first month / day
-        value, eg '1904' -> '1904-01-01'.
-
         Returns a tuple with the start and end date values, both of which
         can be None if not found
         """

--- a/ckanext/dcat/tests/profiles/base/test_base_profile.py
+++ b/ckanext/dcat/tests/profiles/base/test_base_profile.py
@@ -510,7 +510,7 @@ class TestBaseRDFProfile(object):
             <dct:PeriodOfTime>
               <time:hasBeginning>
                 <time:Instant>
-                  <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDateTime>
+                  <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDateTime>
                 </time:Instant>
               </time:hasBeginning>
               <time:hasEnd>
@@ -532,7 +532,7 @@ class TestBaseRDFProfile(object):
 
         start, end = p._time_interval(URIRef('http://example.org'), DCT.temporal)
 
-        assert start == '1904-01-01'
+        assert start == '1904'
         assert end == '2014-03-22'
 
     def test_time_interval_w3c_time_inXSDDateTimeStamp(self):
@@ -548,7 +548,7 @@ class TestBaseRDFProfile(object):
             <dct:PeriodOfTime>
               <time:hasBeginning>
                 <time:Instant>
-                  <time:inXSDDateTimeStamp rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDateTimeStamp>
+                  <time:inXSDDateTimeStamp rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDateTimeStamp>
                 </time:Instant>
               </time:hasBeginning>
               <time:hasEnd>
@@ -570,7 +570,7 @@ class TestBaseRDFProfile(object):
 
         start, end = p._time_interval(URIRef('http://example.org'), DCT.temporal)
 
-        assert start == '1904-01-01'
+        assert start == '1904'
         assert end == '2014-03-22'
 
     def test_time_interval_w3c_time_inXSDDate(self):
@@ -586,7 +586,7 @@ class TestBaseRDFProfile(object):
             <dct:PeriodOfTime>
               <time:hasBeginning>
                 <time:Instant>
-                  <time:inXSDDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDate>
+                  <time:inXSDDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDate>
                 </time:Instant>
               </time:hasBeginning>
               <time:hasEnd>
@@ -608,7 +608,7 @@ class TestBaseRDFProfile(object):
 
         start, end = p._time_interval(URIRef('http://example.org'), DCT.temporal)
 
-        assert start == '1904-01-01'
+        assert start == '1904'
         assert end == '2014-03-22'
 
     def test_time_interval_multiple_w3c_time(self):
@@ -627,9 +627,9 @@ class TestBaseRDFProfile(object):
             <dct:PeriodOfTime>
               <time:hasBeginning>
                 <time:Instant>
-                  <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2005</time:inXSDDateTime>
-                  <time:inXSDDateTimeStamp rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDateTimeStamp>
-                  <time:inXSDDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1974</time:inXSDDate>
+                  <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">2005</time:inXSDDateTime>
+                  <time:inXSDDateTimeStamp rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDateTimeStamp>
+                  <time:inXSDDate rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1974</time:inXSDDate>
                 </time:Instant>
               </time:hasBeginning>
               <time:hasEnd>
@@ -653,7 +653,7 @@ class TestBaseRDFProfile(object):
 
         start, end = p._time_interval(URIRef('http://example.org'), DCT.temporal)
 
-        assert start == '1904-01-01'
+        assert start == '1904'
         assert end == '2014-03-22'
 
     def test_time_interval_dcat(self):
@@ -706,7 +706,7 @@ class TestBaseRDFProfile(object):
                 <dct:PeriodOfTime>
                   <time:hasBeginning>
                     <time:Instant>
-                      <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDateTime>
+                      <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDateTime>
                     </time:Instant>
                   </time:hasBeginning>
                   <time:hasEnd>
@@ -763,7 +763,7 @@ class TestBaseRDFProfile(object):
                 <dct:PeriodOfTime>
                   <time:hasBeginning>
                     <time:Instant>
-                      <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDateTime>
+                      <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDateTime>
                     </time:Instant>
                   </time:hasBeginning>
                   <time:hasEnd>
@@ -827,7 +827,7 @@ class TestBaseRDFProfile(object):
                 <dct:PeriodOfTime>
                     <time:hasBeginning>
                         <time:Instant>
-                        <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1904</time:inXSDDateTime>
+                        <time:inXSDDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">1904</time:inXSDDateTime>
                         </time:Instant>
                     </time:hasBeginning>
                     <time:hasEnd>
@@ -849,7 +849,7 @@ class TestBaseRDFProfile(object):
 
         start, end = p._time_interval(URIRef('http://example.org'), DCT.temporal, dcat_ap_version=2)
 
-        assert start == '1904-01-01'
+        assert start == '1904'
         assert end == '2014-03-22'
 
     def test_publisher_foaf(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rdflib>=6.1.1,<7.1.0
+rdflib>=6.1.1,<7.2.0
 geomet>=0.2.0
 ckantoolkit>=0.0.7
 future>=0.18.2


### PR DESCRIPTION
Rdflib 7.1.0 introduced changes in [date parsing][1] that made some base profile tests fail. Basically the previous rdflib versions incomplete dates like

    <time:inXSDDateTimeStamp
         rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
            1904
    </time:inXSDDateTimeStamp>

were expanded to `1904-01-01`. Of course this is not a valid date and should be expressed using `gYear`:

    <time:inXSDDateTimeStamp
         rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear">
            1904
    </time:inXSDDateTimeStamp>

and we should be expecting `1904`.
This should play nice with the time properties we are generating in CKAN as they already handle automatically `gYear`, `gYearMonth`, `date` and `dateTime`.
Sites importing external DCAT representations that use the wrong encoding might need to check their parsers.

[1] https://github.com/RDFLib/rdflib/pull/2929