### PR TITLE
Fix parsing of spatial properties when using scheming

### DIFF
--- a/ckanext/dcat/profiles/euro_dcat_ap_scheming.py
+++ b/ckanext/dcat/profiles/euro_dcat_ap_scheming.py
@@ -77,7 +77,10 @@ class EuropeanDCATAPSchemingProfile(RDFProfile):
                 _parse_list_value(resource_dict, field_name)
 
         # Repeating subfields
-        new_fields_mapping = {"temporal_coverage": "temporal"}
+        new_fields_mapping = {
+            "spatial_coverage": "spatial",
+            "temporal_coverage": "temporal",
+        }
         for schema_field in self._dataset_schema["dataset_fields"]:
             if "repeating_subfields" in schema_field:
                 # Check if existing extras need to be migrated
@@ -94,6 +97,9 @@ class EuropeanDCATAPSchemingProfile(RDFProfile):
                             new_dict[subfield] = extra["value"]
                         else:
                             new_extras.append(extra)
+                    elif extra["key"] == "spatial" and field_name == "spatial_coverage":
+                        # Special case, spatial geom
+                        new_dict["geom"] = extra["value"]
                     else:
                         new_extras.append(extra)
                 if new_dict:

--- a/ckanext/dcat/tests/profiles/dcat_ap_2/test_scheming_support.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap_2/test_scheming_support.py
@@ -741,6 +741,12 @@ class TestSchemingParseSupport(BaseParseTest):
         assert dataset["temporal_coverage"][0]["start"] == "1905-03-01"
         assert dataset["temporal_coverage"][0]["end"] == "2013-01-05"
 
+        assert (
+            dataset["spatial_coverage"][0]["uri"]
+            == "http://publications.europa.eu/mdr/authority/country/ZWE"
+        )
+        assert dataset["spatial_coverage"][0]["geom"]
+
         resource = dataset["resources"][0]
 
         # Resources: core fields

--- a/examples/dcat/dataset.rdf
+++ b/examples/dcat/dataset.rdf
@@ -9,6 +9,7 @@
     xmlns:adms="http://www.w3.org/ns/adms#"
     xmlns:schema="http://schema.org/"
 	xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+    xmlns:locn="http://www.w3.org/ns/locn#"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:spdx="http://spdx.org/rdf/terms#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
@@ -38,6 +39,11 @@
     <dct:conformsTo>Standard 2</dct:conformsTo>
     <dct:license rdf:resource="https://data.some.org/link/to/license"/>
     <dct:spatial rdf:resource="http://publications.europa.eu/mdr/authority/country/ZWE"/>
+    <dct:spatial>
+      <dct:Location>
+        <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">POLYGON ((11.9936 54.0486, 11.9936 54.2466, 12.3045 54.2466, 12.3045 54.0486, 11.9936 54.0486))</locn:geometry>
+      </dct:Location>
+    </dct:spatial>
     <dcat:spatialResolutionInMeters rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1.5</dcat:spatialResolutionInMeters>
     <dct:accrualPeriodicity rdf:resource="http://purl.org/cld/freq/daily"/>
     <dct:accessRights>public</dct:accessRights>


### PR DESCRIPTION
Legacy `spatial_*` extras were not converted to the repeating subfield `spatial_coverage`