### PR TITLE
Dataset relations POC

### DIFF
--- a/ckanext/dcat/profiles/base.py
+++ b/ckanext/dcat/profiles/base.py
@@ -10,7 +10,7 @@ from geomet import InvalidGeoJSONException, wkt
 from rdflib import BNode, Literal, URIRef, term
 from rdflib.namespace import ORG, RDF, RDFS, SKOS, XSD, Namespace
 
-from ckanext.dcat.utils import DCAT_EXPOSE_SUBCATALOGS
+from ckanext.dcat.utils import DCAT_EXPOSE_SUBCATALOGS, dataset_uri
 from ckanext.dcat.validators import is_date, is_year, is_year_month
 
 CNT = Namespace("http://www.w3.org/2011/content#")
@@ -1006,6 +1006,36 @@ class RDFProfile(object):
 
     def _add_list_triples_from_dict(self, _dict, subject, items):
         self._add_triples_from_dict(_dict, subject, items, list_value=True)
+
+    def _add_list_dataset_triples_from_dict(self, _dict, subject, items):
+        for item in items:
+            try:
+                key, predicate, fallbacks, _type, _class = item
+            except ValueError:
+                key, predicate, fallbacks, _type = item
+                _class = None
+            self._add_triple_from_dict(
+                _dict,
+                subject,
+                predicate,
+                key,
+                fallbacks=fallbacks,
+                list_value=True,
+                _type=_type,
+                _class=_class,
+                value_modifier=self._get_local_uri
+            )
+
+    def _get_local_uri(self, value):
+
+        items = self._read_list_value(value)
+        new_items = []
+        for item in items:
+            if item.startswith("http://") or item.startswith("https://"):
+                new_items.append(item)
+            else:
+                new_items.append(dataset_uri({"id": item}))
+        return new_items
 
     def _add_triples_from_dict(
         self, _dict, subject, items, list_value=False, date_value=False

--- a/ckanext/dcat/profiles/euro_dcat_ap_base.py
+++ b/ckanext/dcat/profiles/euro_dcat_ap_base.py
@@ -372,13 +372,19 @@ class BaseEuropeanDCATAPProfile(RDFProfile):
             ("theme", DCAT.theme, None, URIRef),
             ("conforms_to", DCT.conformsTo, None, URIRefOrLiteral, DCT.Standard),
             ("documentation", FOAF.page, None, URIRefOrLiteral, FOAF.Document),
+            ("sample", ADMS.sample, None, URIRefOrLiteral, DCAT.Distribution),
+        ]
+        self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
+
+
+        items = [
             ("related_resource", DCT.relation, None, URIRefOrLiteral, RDFS.Resource),
             ("has_version", DCT.hasVersion, None, URIRefOrLiteral),
             ("is_version_of", DCT.isVersionOf, None, URIRefOrLiteral),
             ("source", DCT.source, None, URIRefOrLiteral),
-            ("sample", ADMS.sample, None, URIRefOrLiteral, DCAT.Distribution),
         ]
-        self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
+        self._add_list_dataset_triples_from_dict(dataset_dict, dataset_ref, items)
+
 
         # Contact details
         if any(

--- a/ckanext/dcat/schemas/dcat_ap_full.yaml
+++ b/ckanext/dcat/schemas/dcat_ap_full.yaml
@@ -263,10 +263,13 @@ dataset_fields:
 
 - field_name: has_version
   label: Has version
-  preset: multiple_text
-  validators: ignore_missing scheming_multiple_text
-  help_inline: true
+  preset: dataset_relation
   help_text: This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.
+
+- field_name: source
+  label: Source
+  preset: dataset_relation
+  help_text: A related Dataset from which the described Dataset is derived.
 
 - field_name: qualified_relation
   label: Qualified relation

--- a/ckanext/dcat/schemas/presets.yaml
+++ b/ckanext/dcat/schemas/presets.yaml
@@ -10,3 +10,14 @@ presets:
     form_snippet: date.html
     display_snippet: dcat_date.html
     validators: ignore_missing dcat_date convert_to_json_if_datetime
+
+
+- preset_name: dataset_relation
+  values:
+    # TODO: Widget to select existing datasets
+    form_snippet: multiple_text.html
+    # TODO: Snippet that turns ids into dataset page links
+    display_snippet: multiple_text.html
+    validators: ignore_missing scheming_multiple_text dataset_id_or_uri
+    output_validators: scheming_load_json
+    help_inline: true


### PR DESCRIPTION
This change implements a potential approach for handling relations between datasets as discussed in #331. It explores the "store relations in dataset metadata" approach rather than the "store relations in a separate db" 

Right now it comprises mainly two sides:

* A `dataset_relation` preset that extends the `multiple_text` one to add a custom validator and eventually custom form/display snippets. The validator checks that the field items are either a valid dataset id or a URI. The form widget would allow to choose existing datasets in the site or paste a URI.
* Changes in the base profiles to handle certain fields like `has_version` or `source`. When serializing, if the value is an URI is left unchanged but if it's a dataset id, a dataset URI is generated for it

This allows us to go from the current serialization where we just dump whatever there is in e.g. the `has_version` field:

```turtle
@prefix dcat: <http://www.w3.org/ns/dcat#> .
@prefix dct: <http://purl.org/dc/terms/> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<http://localhost:5015/dataset/bdde0f9f-6311-4770-a3b8-e946c822d629> a dcat:Dataset ;
    dct:description "sadas" ;
    dct:hasVersion <http://some.uri.somewhere.else>,
        "fd2c4eaf-0bc3-48d1-8d3f-58e73f8c674d" ;
    dct:identifier "bdde0f9f-6311-4770-a3b8-e946c822d629" .
```

To exposing actual URIs to the other datasets in the catalog:

```turtle
@prefix dcat: <http://www.w3.org/ns/dcat#> .
@prefix dct: <http://purl.org/dc/terms/> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<http://localhost:5015/dataset/bdde0f9f-6311-4770-a3b8-e946c822d629> a dcat:Dataset ;
    dct:description "sadas" ;
    dct:hasVersion <http://localhost:5015/dataset/fd2c4eaf-0bc3-48d1-8d3f-58e73f8c674d>,
        <http://some.uri.somewhere.else> ;
    dct:identifier "bdde0f9f-6311-4770-a3b8-e946c822d629"
```

Other things that are missing:

* Avoiding stale relations, .e.g. what happens when a dataset involved in a relation is deleted? This could be handled with an `after_dataset_deleted` hook that fires a background job that uses the search to find datasets that use the deleted dataset id an relation and patch them the remove that relation (This would require indexing the relation field values as lists)
* If desirable, another background job could create the inverse relations (e.g. `is_version_of`) although DCAT-AP 3 explicitly says that these [are not necessary](https://semiceu.github.io/DCAT-AP/releases/3.0.0/#inverse-properties).
* Form widget: uses the search to get a list of datasets matching a query (might be tricky in sites with many datasets to find the one you want), or you can paste a dataset page URL or an external URI. 
* Display widget: here we'll have the common problem that we are just storing an id but we probably want a title and a name in the template to generate a link. We then either need to call package_show on each page request or store this info somehow at index time, but then it can get stale if the title is updated.

