### PR TITLE
Add support for Croissant RecordSet objects

### DIFF
--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -527,36 +527,32 @@ class CroissantProfile(RDFProfile):
 
         self.g.add((recordset_ref, RDF.type, CR.RecordSet))
 
-        #        self.g.add((recordset_ref, RDF.type, SCHEMA.Text))
-
-        self.g.add((recordset_ref, SCHEMA.name, Literal(recordset_ref)))
-
         unique_fields = []
 
         for field in datastore_info["fields"]:
 
             field_ref = URIRef(f"{resource_dict['id']}/records/{field['id']}")
 
-            self.g.add((recordset_ref, SCHEMA.field, field_ref))
+            self.g.add((recordset_ref, CR.field, field_ref))
             self.g.add((field_ref, RDF.type, CR.Field))
             if field_type := CROISSANT_FIELD_TYPES.get(field["type"]):
                 self.g.add((field_ref, CR.dataType, field_type))
 
             source_ref = BNode()
 
-            self.g.add((field_ref, SCHEMA.source, source_ref))
-            self.g.add((source_ref, SCHEMA.fileObject, resource_ref))
+            self.g.add((field_ref, CR.source, source_ref))
+            self.g.add((source_ref, CR.fileObject, resource_ref))
 
             extract_ref = BNode()
 
-            self.g.add((source_ref, SCHEMA.extract, extract_ref))
-            self.g.add((extract_ref, SCHEMA.column, Literal(field['id'])))
+            self.g.add((source_ref, CR.extract, extract_ref))
+            self.g.add((extract_ref, CR.column, Literal(field['id'])))
 
             if field["schema"]["is_index"]:
                 unique_fields.append(field_ref)
 
         if unique_fields:
             for unique_field_ref in unique_fields:
-                self.g.add((recordset_ref, SCHEMA.key, unique_field_ref))
+                self.g.add((recordset_ref, CR.key, unique_field_ref))
 
         self.g.add((dataset_ref, CR.recordSet, recordset_ref))

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -65,7 +65,7 @@ CROISSANT_FIELD_TYPES = {
     "int": SCHEMA.Integer,
     "float": SCHEMA.Float,
     "numeric": SCHEMA.Float,
-    "timestamp": SCHEMA.DateTime,
+    "timestamp": SCHEMA.Date,
 }
 
 

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -156,8 +156,11 @@ class CroissantProfile(RDFProfile):
         dataset_url = url_for("dataset.read", id=dataset_dict["name"], _external=True) # required
         self.g.add((dataset_ref, SCHEMA.url, Literal(dataset_url)))
 
-        if 'is_live_dataset' in dataset_dict:
-            is_live_dataset = asbool(dataset_dict["is_live_dataset"])
+        if "is_live_dataset" in dataset_dict:
+            try:
+                is_live_dataset = asbool(dataset_dict["is_live_dataset"])
+            except ValueError:
+                is_live_dataset = None
         else:
             is_live_dataset = None
 

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -70,7 +70,7 @@ CROISSANT_FIELD_TYPES = {
     "float8": SCHEMA.Float,
     "numeric": SCHEMA.Float,
     "double precision": SCHEMA.Float,
-    "timestamp": SCHEMA.DateTime,
+    "timestamp": SCHEMA.Date,
 }
 
 

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -439,11 +439,7 @@ class CroissantProfile(RDFProfile):
         self._add_list_triples_from_dict(resource_dict, resource_ref, items)
 
     def _resource_format_graph(self, resource_ref, resource_dict):
-        if resource_dict.get("format"):
-            self.g.add(
-                (resource_ref, SCHEMA.encodingFormat, Literal(resource_dict["format"]))
-            )
-        elif resource_dict.get("mimetype"):
+        if resource_dict.get("mimetype"):
             self.g.add(
                 (
                     resource_ref,
@@ -451,6 +447,11 @@ class CroissantProfile(RDFProfile):
                     Literal(resource_dict["mimetype"]),
                 )
             )
+        elif resource_dict.get("format"):
+            self.g.add(
+                (resource_ref, SCHEMA.encodingFormat, Literal(resource_dict["format"]))
+            )
+
 
     def _resource_url_graph(self, resource_ref, resource_dict):
         if (resource_dict.get("type") == "fileObject") and resource_dict.get("url"):

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -68,6 +68,15 @@ JSONLD_CONTEXT = {
     "transform": "cr:transform"
 }
 
+CROISSANT_FIELD_TYPES = {
+    "text": SCHEMA.Text,
+    "int": SCHEMA.Integer,
+    "float": SCHEMA.Float,
+    "numeric": SCHEMA.Float,
+    "timestamp": SCHEMA.DateTime,
+}
+
+
 class CroissantProfile(RDFProfile):
     """
     An RDF profile based on the schema.org Dataset, modified by Croissant.
@@ -442,28 +451,19 @@ class CroissantProfile(RDFProfile):
 
         self.g.add((recordset_ref, RDF.type, CR.RecordSet))
 
-#        self.g.add((recordset_ref, RDF.type, SCHEMA.Text))
+        #        self.g.add((recordset_ref, RDF.type, SCHEMA.Text))
 
         self.g.add((recordset_ref, SCHEMA.name, Literal(recordset_ref)))
 
-        FIELD_TYPES = {
-            "text": SCHEMA.Text,
-            "int": SCHEMA.Integer,
-            "float": SCHEMA.Float,
-            "numeric": SCHEMA.Float,
-            "timestamp": SCHEMA.DateTime,
-        }
-
         unique_fields = []
         for field in datastore_info["fields"]:
-
 
             field_ref = URIRef(f"{resource_dict['id']}/records/{field['id']}")
 
             self.g.add((recordset_ref, SCHEMA.field, field_ref))
             self.g.add((field_ref, RDF.type, CR.Field))
 
-            self.g.add((field_ref, CR.dataType, FIELD_TYPES.get(field["type"])))
+            self.g.add((field_ref, CR.dataType, CROISSANT_FIELD_TYPES.get(field["type"])))
 
             source_ref = BNode()
 

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -63,9 +63,14 @@ JSONLD_CONTEXT = {
 CROISSANT_FIELD_TYPES = {
     "text": SCHEMA.Text,
     "int": SCHEMA.Integer,
+    "int4": SCHEMA.Integer,
+    "int8": SCHEMA.Integer,
     "float": SCHEMA.Float,
+    "float4": SCHEMA.Float,
+    "float8": SCHEMA.Float,
     "numeric": SCHEMA.Float,
-    "timestamp": SCHEMA.Date,
+    "double precision": SCHEMA.Float,
+    "timestamp": SCHEMA.DateTime,
 }
 
 
@@ -527,14 +532,15 @@ class CroissantProfile(RDFProfile):
         self.g.add((recordset_ref, SCHEMA.name, Literal(recordset_ref)))
 
         unique_fields = []
+
         for field in datastore_info["fields"]:
 
             field_ref = URIRef(f"{resource_dict['id']}/records/{field['id']}")
 
             self.g.add((recordset_ref, SCHEMA.field, field_ref))
             self.g.add((field_ref, RDF.type, CR.Field))
-
-            self.g.add((field_ref, CR.dataType, CROISSANT_FIELD_TYPES.get(field["type"])))
+            if field_type := CROISSANT_FIELD_TYPES.get(field["type"]):
+                self.g.add((field_ref, CR.dataType, field_type))
 
             source_ref = BNode()
 

--- a/ckanext/dcat/tests/profiles/croissant/test_serialize.py
+++ b/ckanext/dcat/tests/profiles/croissant/test_serialize.py
@@ -284,6 +284,7 @@ class TestCroissantProfileSerializeDataset(BaseSerializeTest):
         fields_datastore = [
             {"id": "name", "type": "text", "schema": {"is_index": True}},
             {"id": "age", "type": "int", "schema": {"is_index": False}},
+            {"id": "temperature", "type": "float", "schema": {"is_index": False}},
             {"id": "timestamp", "type": "timestamp", "schema": {"is_index": False}},
         ]
 
@@ -311,7 +312,7 @@ class TestCroissantProfileSerializeDataset(BaseSerializeTest):
 
             # Test fields
             fields = list(g.objects(recordset_ref, SCHEMA.field))
-            assert len(fields) == 3
+            assert len(fields) == 4
 
             for field_datastore in fields_datastore:
                 field_ref = URIRef(f"{resource_id}/records/{field_datastore['id']}")

--- a/ckanext/dcat/tests/profiles/croissant/test_serialize.py
+++ b/ckanext/dcat/tests/profiles/croissant/test_serialize.py
@@ -310,31 +310,30 @@ class TestCroissantProfileSerializeDataset(BaseSerializeTest):
             recordset_ref = URIRef(f"{resource_id}/records")
             assert self._triple(g, dataset_ref, CR.recordSet, recordset_ref)
             assert self._triple(g, recordset_ref, RDF.type, CR.RecordSet)
-            assert self._triple(g, recordset_ref, SCHEMA.name, str(recordset_ref))
 
             # Test fields
-            fields = list(g.objects(recordset_ref, SCHEMA.field))
+            fields = list(g.objects(recordset_ref, CR.field))
             assert len(fields) == 4
 
             for field_datastore in fields_datastore:
                 field_ref = URIRef(f"{resource_id}/records/{field_datastore['id']}")
 
-                assert self._triple(g, recordset_ref, SCHEMA.field, field_ref)
+                assert self._triple(g, recordset_ref, CR.field, field_ref)
 
                 assert self._triple(
                     g, field_ref, CR.dataType, CROISSANT_FIELD_TYPES.get(field_datastore["type"])
                 )
 
-                source_ref = list(g.objects(field_ref, SCHEMA.source))[0]
+                source_ref = list(g.objects(field_ref, CR.source))[0]
 
-                assert self._triple(g, source_ref, SCHEMA.fileObject, resource_ref)
+                assert self._triple(g, source_ref, CR.fileObject, resource_ref)
 
-                extract_ref = list(g.objects(source_ref, SCHEMA.extract))[0]
+                extract_ref = list(g.objects(source_ref, CR.extract))[0]
 
-                assert self._triple(g, extract_ref, SCHEMA.column, field_datastore["id"])
+                assert self._triple(g, extract_ref, CR.column, field_datastore["id"])
 
             assert self._triple(
-                g, recordset_ref, SCHEMA.key, URIRef(f"{resource_id}/records/name")
+                g, recordset_ref, CR.key, URIRef(f"{resource_id}/records/name")
             )
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")

--- a/ckanext/dcat/tests/profiles/croissant/test_serialize.py
+++ b/ckanext/dcat/tests/profiles/croissant/test_serialize.py
@@ -1,5 +1,7 @@
 from builtins import str
 import json
+from unittest import mock
+import uuid
 
 import pytest
 
@@ -14,7 +16,7 @@ from ckantoolkit.tests import helpers, factories
 from ckanext.dcat import utils
 from ckanext.dcat.profiles import XSD, DCT, FOAF
 from ckanext.dcat.processors import RDFSerializer
-from ckanext.dcat.profiles.croissant import SCHEMA, CR
+from ckanext.dcat.profiles.croissant import SCHEMA, CR, CROISSANT_FIELD_TYPES
 
 from ckanext.dcat.tests.profiles.dcat_ap.test_euro_dcatap_profile_serialize import (
     BaseSerializeTest,
@@ -259,3 +261,75 @@ class TestCroissantProfileSerializeDataset(BaseSerializeTest):
             CR.excludes,
             sub_resource_file_set_dict["excludes"],
         )
+
+    def test_graph_from_dataset_with_recordset(self):
+
+        dataset_id = str(uuid.uuid4())
+        resource_id = str(uuid.uuid4())
+
+        dataset_dict = {
+            "id": dataset_id,
+            "name": "test-dataset",
+            "title": "Test Dataset",
+            "notes": "Test description",
+            "resources": [
+                {
+                    "id": resource_id,
+                    "url": "http://example.com/data.csv",
+                    "format": "CSV",
+                    "datastore_active": True,
+                }
+            ],
+        }
+        fields_datastore = [
+            {"id": "name", "type": "text", "schema": {"is_index": True}},
+            {"id": "age", "type": "int", "schema": {"is_index": False}},
+            {"id": "timestamp", "type": "timestamp", "schema": {"is_index": False}},
+        ]
+
+        def mock_datastore_info(context, data_dict):
+            return {
+                "meta": {"id": resource_id, "count": 10, "table_type": "BASE TABLE"},
+                "fields": fields_datastore,
+            }
+
+        with mock.patch(
+            "ckanext.dcat.profiles.croissant.get_action"
+        ) as mock_get_action:
+            mock_get_action.return_value = mock_datastore_info
+
+            s = RDFSerializer(profiles=["croissant"])
+            g = s.g
+
+            dataset_ref = s.graph_from_dataset(dataset_dict)
+            resource_ref = list(g.objects(dataset_ref, SCHEMA.distribution))[0]
+
+            recordset_ref = URIRef(f"{resource_id}/records")
+            assert self._triple(g, dataset_ref, CR.recordSet, recordset_ref)
+            assert self._triple(g, recordset_ref, RDF.type, CR.RecordSet)
+            assert self._triple(g, recordset_ref, SCHEMA.name, str(recordset_ref))
+
+            # Test fields
+            fields = list(g.objects(recordset_ref, SCHEMA.field))
+            assert len(fields) == 3
+
+            for field_datastore in fields_datastore:
+                field_ref = URIRef(f"{resource_id}/records/{field_datastore['id']}")
+
+                assert self._triple(g, recordset_ref, SCHEMA.field, field_ref)
+
+                assert self._triple(
+                    g, field_ref, CR.dataType, CROISSANT_FIELD_TYPES.get(field_datastore["type"])
+                )
+
+                source_ref = list(g.objects(field_ref, SCHEMA.source))[0]
+
+                assert self._triple(g, source_ref, SCHEMA.fileObject, resource_ref)
+
+                extract_ref = list(g.objects(source_ref, SCHEMA.extract))[0]
+
+                assert self._triple(g, extract_ref, SCHEMA.column, field_datastore["id"])
+
+            assert self._triple(
+                g, recordset_ref, SCHEMA.key, URIRef(f"{resource_id}/records/name")
+            )

--- a/ckanext/dcat/tests/profiles/croissant/test_validate.py
+++ b/ckanext/dcat/tests/profiles/croissant/test_validate.py
@@ -57,6 +57,7 @@ def test_valid_output_with_recordset():
             "fields": [
                 {"id": "name", "type": "text", "schema": {"is_index": True}},
                 {"id": "age", "type": "int", "schema": {"is_index": False}},
+                {"id": "temperature", "type": "float", "schema": {"is_index": False}},
                 {"id": "timestamp", "type": "timestamp", "schema": {"is_index": False}},
             ],
         }

--- a/ckanext/dcat/tests/profiles/croissant/test_validate.py
+++ b/ckanext/dcat/tests/profiles/croissant/test_validate.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from unittest import mock
 
 try:
     import mlcroissant as mlc
@@ -15,7 +16,7 @@ from ckanext.dcat.tests.utils import get_file_contents
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="croissant is not available in py<3.10"
+    sys.version_info < (3, 10), reason="mlcroissant is not available in py<3.10"
 )
 def test_valid_output():
 
@@ -37,3 +38,43 @@ def test_valid_output():
         mlc.Dataset(croissant_dict)
     except mlc.ValidationError as exception:
         raise
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="mlcroissant is not available in py<3.10"
+)
+def test_valid_output_with_recordset():
+
+    dataset_dict = json.loads(
+        get_file_contents("ckan/ckan_full_dataset_croissant.json")
+    )
+
+    resource_id = dataset_dict["resources"][0]["id"]
+
+    def mock_datastore_info(context, data_dict):
+        return {
+            "meta": {"id": resource_id, "count": 10, "table_type": "BASE TABLE"},
+            "fields": [
+                {"id": "name", "type": "text", "schema": {"is_index": True}},
+                {"id": "age", "type": "int", "schema": {"is_index": False}},
+                {"id": "timestamp", "type": "timestamp", "schema": {"is_index": False}},
+            ],
+        }
+
+    with mock.patch("ckanext.dcat.profiles.croissant.get_action") as mock_get_action:
+        mock_get_action.return_value = mock_datastore_info
+
+        s = RDFSerializer(profiles=["croissant"])
+
+        s.graph_from_dataset(dataset_dict)
+
+        croissant_dict = json.loads(
+            s.g.serialize(format="json-ld", auto_compact=True, context=JSONLD_CONTEXT)
+        )
+        with open("graph.jsonld", "w") as f:
+            f.write(json.dumps(croissant_dict))
+
+        try:
+            mlc.Dataset(croissant_dict)
+        except mlc.ValidationError as exception:
+            raise

--- a/docs/croissant.md
+++ b/docs/croissant.md
@@ -21,7 +21,14 @@ Once the plugin is enabled, the Croissant output will be embedded in the source 
 
     https://{ckan-instance-host}/dataset/{dataset-id}/croissant.jsonld
 
+## Schema mapping
+
 The extension includes a [schema](getting-started.md#schemas) ([`ckanext/dcat/schemas/croissant.yaml`](https://github.com/ckan/ckanext-dcat/tree/master/ckanext/dcat/schemas/croissant.yml)) for sites that want to take advantage of all the entities and properties of the Croissant spec.
+
+This maps CKAN's datasets to [schema.org Datasets](https://docs.mlcommons.org/croissant/docs/croissant-spec.html#dataset-level-information) and resources to [Croissant resources](https://docs.mlcommons.org/croissant/docs/croissant-spec.html#resources), which can have type `FileObject` or `FileSet`. For `FileSet` resources, use the "Sub-resources" repeating subfield to describe the contents of the file set.
+
+Additionally, for resources that have been imported to the CKAN [DataStore](https://docs.ckan.org/en/latest/maintaining/datastore.html), the resource will also expose Croissant's [RecordSet](https://docs.mlcommons.org/croissant/docs/croissant-spec.html#recordset) objects with information about the data fields (e.g. column names and types).
+
 
 ## Customizing
 
@@ -36,7 +43,20 @@ ckanext.dcat.croissant.profiles = my_custom_croissant_profile
 ## Examples
 
 * The [`examples/ckan/ckan_full_dataset_croissant.json`](https://github.com/ckan/ckanext-dcat/tree/master/examples/ckan/ckan_full_dataset_croissant.json) file contains a full CKAN dataset dict that implements the custom Croissant schema.
-* Below is the Croissant serialization resulting from the dataset above:
+* Below is the Croissant serialization resulting from the dataset above, and assuming the resource has a DataStore tableassociated with the following structure:
+
+```json
+{
+	"fields": [
+		{"id": "name", "type": "text", "schema": {"is_index": True}},
+		{"id": "age", "type": "int", "schema": {"is_index": False}},
+		{"id": "temperature", "type": "float", "schema": {"is_index": False}},
+		{"id": "timestamp", "type": "timestamp", "schema": {"is_index": False}},
+	]
+}
+
+```
+
 
 ```json
 {
@@ -171,6 +191,68 @@ ckanext.dcat.croissant.profiles = my_custom_croissant_profile
         "identifier": "http://example.org/publisher-id",
         "name": "Test Publisher",
         "url": "https://example.org"
+    },
+    "recordSet": {
+      "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records",
+      "@type": "cr:RecordSet",
+      "field": [
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/temperature",
+          "@type": "cr:Field",
+          "dataType": "Float",
+          "source": {
+            "extract": {
+              "column": "temperature"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id",
+            }
+          }
+        },
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/timestamp",
+          "@type": "cr:Field",
+          "dataType": "Date",
+          "source": {
+            "extract": {
+              "column": "timestamp"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id"
+            }
+          }
+        },
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/name",
+          "@type": "cr:Field",
+          "dataType": "Text",
+          "source": {
+            "extract": {
+              "column": "name"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id"
+            }
+          }
+        },
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/age",
+          "@type": "cr:Field",
+          "dataType": "Integer",
+          "source": {
+            "extract": {
+              "column": "age"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id"
+            }
+          }
+        }
+      ],
+      "key": {
+        "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/name"
+      },
+      "name": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records"
     },
     "sameAs": [
         "https://some.other.catalog/dataset/123",

--- a/examples/ckan/ckan_full_dataset_croissant.json
+++ b/examples/ckan/ckan_full_dataset_croissant.json
@@ -60,6 +60,7 @@
             "id_given": "my-custom-resource-id",
             "size": "12323",
             "hash": "b221d9dbb083a7f33428d7c2a3c3198ae925614d70210e28716ccaa7cd4ddb79",
+            "datastore_active": true,
             "subresources": [
                 {
                     "type": "fileObject",

--- a/examples/croissant/full_croissant_dataset.jsonld
+++ b/examples/croissant/full_croissant_dataset.jsonld
@@ -131,6 +131,68 @@
         "name": "Test Publisher",
         "url": "https://example.org"
     },
+    "recordSet": {
+      "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records",
+      "@type": "cr:RecordSet",
+      "field": [
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/temperature",
+          "@type": "cr:Field",
+          "dataType": "Float",
+          "source": {
+            "extract": {
+              "column": "temperature"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id",
+            }
+          }
+        },
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/timestamp",
+          "@type": "cr:Field",
+          "dataType": "Date",
+          "source": {
+            "extract": {
+              "column": "timestamp"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id"
+            }
+          }
+        },
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/name",
+          "@type": "cr:Field",
+          "dataType": "Text",
+          "source": {
+            "extract": {
+              "column": "name"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id"
+            }
+          }
+        },
+        {
+          "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/age",
+          "@type": "cr:Field",
+          "dataType": "Integer",
+          "source": {
+            "extract": {
+              "column": "age"
+            },
+            "fileObject": {
+              "@id": "my-custom-resource-id"
+            }
+          }
+        }
+      ],
+      "key": {
+        "@id": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records/name"
+      },
+      "name": "568b8ac9-8c69-4475-b35e-d7f812a63c32/records"
+    },
     "sameAs": [
         "https://some.other.catalog/dataset/123",
         "https://yet.another.catalog/dataset/xyz"


### PR DESCRIPTION
From the new docs:

> for resources that have been imported to the CKAN [DataStore](https://docs.ckan.org/en/latest/maintaining/datastore.html), the resource will also expose Croissant's [RecordSet](https://docs.mlcommons.org/croissant/docs/croissant-spec.html#recordset) objects with information about the data fields (e.g. column names and types).

DataStore imported tables is the closest that CKAN has right now to a source for identifying the data structure of the data files hosted, and this info really adds value for integration with ML processes and pipelines.

---
To test this the DataStore needs to be configured and some data imported:

1. Set up the [DataStore](https://docs.ckan.org/en/latest/maintaining/datastore.html#setting-up-the-datastore)
2. Get some data, either by enabling and running the [Xloader extension](https://github.com/ckan/ckanext-xloader) or by pushing data directly with a script like the following:

```
curl -X POST \
  'http://CHANGE_ME/api/3/action/datastore_create' \
  -H "Authorization: CHANGE_ME" \
  -H 'Content-Type: application/json' \
  -d '{
    "resource": {
      "package_id": "CHANGE_ME",
      "name": "Air quality",
      "description": "Test data"
    },
    "fields": [
      {
        "id": "measurement_id",
        "type": "text",
        "primary_key": true
      },
      {
        "id": "timestamp",
        "type": "timestamp"
      },
      {
        "id": "location_name",
        "type": "text"
      },
      {
        "id": "temperature_celsius",
        "type": "float"
      },
      {
        "id": "humidity_percent",
        "type": "float"
      },
      {
        "id": "pm25_concentration",
        "type": "float"
      }
    ],
    "records": [
      {
        "measurement_id": "AQ001",
        "timestamp": "2025-02-20T09:30:00",
        "location_name": "Downtown Station",
        "temperature_celsius": 22.5,
        "humidity_percent": 45.3,
        "pm25_concentration": 12.8
      },
      {
        "measurement_id": "AQ002",
        "timestamp": "2025-02-20T10:15:00",
        "location_name": "Industrial Zone",
        "temperature_celsius": 24.1,
        "humidity_percent": 42.7,
        "pm25_concentration": 18.5
      },
      {
        "measurement_id": "AQ003",
        "timestamp": "2025-02-20T11:00:00",
        "location_name": "Residential Area",
        "temperature_celsius": 21.8,
        "humidity_percent": 48.2,
        "pm25_concentration": 8.3
      }
    ],
    "primary_key": ["measurement_id"],
    "indexes": ["timestamp", "location_name"],
    "force": true
}'
```
