### PR TITLE
Include dependencies in pyproject, update install docs

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+# Publish to PyPI when a tag is pushed
+on:
+  push:
+    tags:
+      - 'v**'
+
+jobs:
+  build:
+    if: github.repository == 'ckan/ckanext-dcat'
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution on PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ckanext-dcat
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  publishSkipped:
+    if: github.repository != 'ckan/ckanext-dcat'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "## Skipping PyPI publish on downstream repository" >> $GITHUB_STEP_SUMMARY

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 recursive-include ckanext/dcat/i18n *
 recursive-include ckanext/dcat/templates *
+recursive-include ckanext *.yaml
+recursive-include ckanext *.yml
+include requirements.txt
+include dev-requirements.txt

--- a/ckanext/dcat/converters.py
+++ b/ckanext/dcat/converters.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 import logging
 
 log = logging.getLogger(__name__)

--- a/ckanext/dcat/converters.py
+++ b/ckanext/dcat/converters.py
@@ -23,7 +23,7 @@ def dcat_to_ckan(dcat_dict):
     package_dict['extras'].append({'key': 'guid', 'value': dcat_dict.get('identifier')})
 
     dcat_publisher = dcat_dict.get('publisher')
-    if isinstance(dcat_publisher, basestring):
+    if isinstance(dcat_publisher, str):
         package_dict['extras'].append({'key': 'dcat_publisher_name', 'value': dcat_publisher})
     elif isinstance(dcat_publisher, dict) and dcat_publisher.get('name'):
         package_dict['extras'].append({'key': 'dcat_publisher_name', 'value': dcat_publisher.get('name')})
@@ -38,7 +38,7 @@ def dcat_to_ckan(dcat_dict):
             })
 
     dcat_creator = dcat_dict.get('creator')
-    if isinstance(dcat_creator, basestring):
+    if isinstance(dcat_creator, str):
         package_dict['extras'].append({'key': 'dcat_creator_name', 'value': dcat_creator})
     elif isinstance(dcat_creator, dict) and dcat_creator.get('name'):
         if dcat_creator.get('name'):

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -1,4 +1,3 @@
-from builtins import str
 import json
 import logging
 from hashlib import sha1

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 import json
 import uuid
 import logging

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -134,7 +134,7 @@ class DCATRDFHarvester(DCATHarvester):
         source_config_obj = json.loads(source_config)
         if 'rdf_format' in source_config_obj:
             rdf_format = source_config_obj['rdf_format']
-            if not isinstance(rdf_format, basestring):
+            if not isinstance(rdf_format, str):
                 raise ValueError('rdf_format must be a string')
             supported_formats = RDFParser().supported_formats()
             if rdf_format not in supported_formats:

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -1,4 +1,3 @@
-from builtins import str
 from past.builtins import basestring
 import json
 import uuid

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import math
 
 from ckantoolkit import config

--- a/ckanext/dcat/plugins/__init__.py
+++ b/ckanext/dcat/plugins/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import object
 from functools import wraps
 import os
 import json

--- a/ckanext/dcat/processors.py
+++ b/ckanext/dcat/processors.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-
-from builtins import str
-from builtins import object
 import sys
 import argparse
 import xml

--- a/ckanext/dcat/tests/harvester/test_harvester.py
+++ b/ckanext/dcat/tests/harvester/test_harvester.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import str
-from builtins import range
-from builtins import object
 from collections import defaultdict
 import re
 

--- a/ckanext/dcat/tests/harvester/test_json_harvester.py
+++ b/ckanext/dcat/tests/harvester/test_json_harvester.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from builtins import object
-
 import responses
 import pytest
 try:

--- a/ckanext/dcat/tests/logic/test_logic.py
+++ b/ckanext/dcat/tests/logic/test_logic.py
@@ -1,5 +1,3 @@
-from builtins import range
-from builtins import object
 
 try:
     from unittest import mock

--- a/ckanext/dcat/tests/profiles/base/test_base_parser.py
+++ b/ckanext/dcat/tests/profiles/base/test_base_parser.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 
 import pytest
 

--- a/ckanext/dcat/tests/profiles/base/test_base_profile.py
+++ b/ckanext/dcat/tests/profiles/base/test_base_profile.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 
 import pytest
 

--- a/ckanext/dcat/tests/profiles/base/test_base_serializer.py
+++ b/ckanext/dcat/tests/profiles/base/test_base_serializer.py
@@ -1,4 +1,3 @@
-from builtins import str
 
 from ckantoolkit import config
 

--- a/ckanext/dcat/tests/profiles/croissant/test_serialize.py
+++ b/ckanext/dcat/tests/profiles/croissant/test_serialize.py
@@ -1,4 +1,3 @@
-from builtins import str
 import json
 from unittest import mock
 import uuid

--- a/ckanext/dcat/tests/profiles/dcat_ap/test_euro_dcatap_profile_parse.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap/test_euro_dcatap_profile_parse.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 import json
 
 import pytest

--- a/ckanext/dcat/tests/profiles/dcat_ap/test_euro_dcatap_profile_serialize.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap/test_euro_dcatap_profile_serialize.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 import json
 import uuid
 from decimal import Decimal

--- a/ckanext/dcat/tests/profiles/dcat_ap_2/test_euro_dcatap_2_profile_parse.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap_2/test_euro_dcatap_2_profile_parse.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import str
-from builtins import object
 import os
 import json
 

--- a/ckanext/dcat/tests/profiles/dcat_ap_2/test_euro_dcatap_2_profile_serialize.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap_2/test_euro_dcatap_2_profile_serialize.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import str
-from builtins import object
 import json
 from decimal import Decimal
 import six

--- a/ckanext/dcat/tests/profiles/schemaorg/test_schemaorg_profile_serialize.py
+++ b/ckanext/dcat/tests/profiles/schemaorg/test_schemaorg_profile_serialize.py
@@ -1,4 +1,3 @@
-from builtins import str
 import json
 
 import pytest

--- a/ckanext/dcat/tests/test_blueprints.py
+++ b/ckanext/dcat/tests/test_blueprints.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from builtins import str
-from builtins import range
 import json
 import time
 

--- a/ckanext/dcat/tests/test_converters.py
+++ b/ckanext/dcat/tests/test_converters.py
@@ -1,4 +1,3 @@
-from builtins import object
 import os
 import json
 import difflib

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import str
 import logging
 import uuid
 import simplejson as json

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,17 +5,23 @@
 
 1.  Install the extension in your virtualenv:
 
-        (pyenv) $ pip install -e git+https://github.com/ckan/ckanext-dcat.git#egg=ckanext-dcat
+        pip install ckanext-dcat
 
-2.  Install the extension requirements:
 
-        (pyenv) $ pip install -r ckanext-dcat/requirements.txt
+    !!! Note
 
-3.  Enable the required plugins in your ini file:
+        For versions older than **ckanext-dcat 2.3.0** use the old legacy version of the install:
+
+            pip install -e git+https://github.com/ckan/ckanext-dcat.git#egg=ckanext-dcat
+
+            pip install -r ckanext-dcat/requirements.txt
+
+
+2.  Enable the required plugins in your ini file:
 
         ckan.plugins = dcat dcat_rdf_harvester structured_data
 
-4. To use the pre-built schemas, install [ckanext-scheming](https://github.com/ckan/ckanext-scheming):
+3. To use the pre-built schemas, install [ckanext-scheming](https://github.com/ckan/ckanext-scheming):
 
         pip install -e "git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "ckanext-dcat"
 version = "2.2.0"
+dynamic = ["dependencies", "optional-dependencies"]
 description = "Plugins for exposing and consuming DCAT metadata on CKAN"
 authors = [
     {name = "Adrià Mercader", email = "amercadero@gmail.com"}
@@ -31,7 +32,6 @@ keywords = [
     "RDF",
     "Semantic data"
     ]
-dependencies = []
 
 [project.urls]
 Documentation = "https://docs.ckan.org/projects/ckanext-dcat"
@@ -40,8 +40,12 @@ Issues = "https://github.com/ckan/ckanext-dcat/issues"
 Changelog = "https://docs.ckan.org/projects/ckanext-dcat/en/latest/changelog/"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=62.6.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+optional-dependencies = {dev = { file = ["dev-requirements.txt"] }}
 
 [project.entry-points."ckan.plugins"]
 dcat_xml_harvester = "ckanext.dcat.harvesters:DCATXMLHarvester"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ rdflib>=6.1.1,<7.2.0
 pyld>=2.0.4,<3.0.0
 geomet>=0.2.0
 ckantoolkit>=0.0.7
-future>=0.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rdflib>=6.1.1,<7.2.0
-pyld>=2.0.4,<3.0.0
+rdflib>=6.1.1
+pyld>=2.0.4
 geomet>=0.2.0
 ckantoolkit>=0.0.7


### PR DESCRIPTION
Fixes #340 

Keep the requirements.txt and dev-requirements.txt around and acting like the source of truth, so all existing installation processes keep working as intended but include them dynamically in pyproject.toml to integrate with modern workflows, and to be able to just run:

    pip install ckanext-dcat

The requirements were loosen a bit to adapt to the suggestions by @smotornyuk here:

https://github.com/ckan/ckan/issues/8382#issuecomment-2353188970