### PR TITLE
feat: add trusted_data_holder field to HealthDCAT-AP schema and examples

### DIFF
--- a/ckanext/dcat/profiles/euro_health_dcat_ap.py
+++ b/ckanext/dcat/profiles/euro_health_dcat_ap.py
@@ -35,7 +35,7 @@ class EuropeanHealthDCATAPProfile(EuropeanDCATAP3Profile):
 
     def _parse_health_fields(self, dataset_dict, dataset_ref):
         self.__parse_healthdcat_stringvalues(dataset_dict, dataset_ref)
-
+        self.__parse_healthdcat_booleanvalues(dataset_dict, dataset_ref)
         self.__parse_healthdcat_intvalues(dataset_dict, dataset_ref)
 
         # Add the HDAB. There should only ever be one but you never know
@@ -113,6 +113,15 @@ class EuropeanHealthDCATAPProfile(EuropeanDCATAP3Profile):
         ]
         self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
 
+        if "trusted_data_holder" in dataset_dict:
+            self.g.add(
+                (
+                    dataset_ref,
+                    HEALTHDCATAP.trustedDataHolder,
+                    Literal(bool(dataset_dict["trusted_data_holder"]), datatype=XSD.boolean),
+                )
+            )
+
         items = [
             ("min_typical_age", HEALTHDCATAP.minTypicalAge),
             ("max_typical_age", HEALTHDCATAP.maxTypicalAge),
@@ -147,6 +156,14 @@ class EuropeanHealthDCATAPProfile(EuropeanDCATAP3Profile):
                 )
             except (ValueError, TypeError):
                 self.g.add((dataset_ref, predicate, Literal(value)))
+                
+    def __parse_healthdcat_booleanvalues(self, dataset_dict, dataset_ref):
+        for key, predicate in (
+            ("trusted_data_holder", HEALTHDCATAP.trustedDataHolder),
+        ):
+            value = self._object_value(dataset_ref, predicate)
+            if value is not None:
+                dataset_dict[key] = value.lower() == "true"
 
     def graph_from_catalog(self, catalog_dict, catalog_ref):
         super().graph_from_catalog(catalog_dict, catalog_ref)

--- a/ckanext/dcat/schemas/health_dcat_ap.yaml
+++ b/ckanext/dcat/schemas/health_dcat_ap.yaml
@@ -363,6 +363,19 @@ dataset_fields:
   help_text: >
      A type of organisation that makes the Dataset available.
 
+- field_name: trusted_data_holder
+  label: Trusted Data Holder
+  preset: select
+  choices:
+  - value: false
+    label: "No"
+  - value: true
+    label: "Yes"
+  validators: ignore_missing boolean_validator
+  help_text: >
+    Indicates whether the dataset is held by a trusted data holder.
+  output_validators: boolean_validator
+
 - field_name: population_coverage
   label: Population coverage
   preset: multiple_text

--- a/ckanext/dcat/tests/profiles/health_dcat_ap/test_euro_health_dcat_ap_profile_parse.py
+++ b/ckanext/dcat/tests/profiles/health_dcat_ap/test_euro_health_dcat_ap_profile_parse.py
@@ -168,6 +168,7 @@ class TestSchemingParseSupport(BaseParseTest):
         assert dataset["publisher_type"] == [
             "http://example.com/publisherType/undefined"
         ]
+        assert dataset["trusted_data_holder"] is True
 
         assert dataset["purpose"] == ["https://w3id.org/dpv#AcademicResearch"]
 

--- a/examples/ckan/health_dcat_ap.json
+++ b/examples/ckan/health_dcat_ap.json
@@ -87,6 +87,7 @@
         "publisher_type": [
             "http://example.com/publisherType/undefined"
         ],
+        "trusted_data_holder": true, 
         "purpose": [
             "https://w3id.org/dpv#AcademicResearch"
         ],

--- a/examples/dcat/dataset_health.ttl
+++ b/examples/dcat/dataset_health.ttl
@@ -46,6 +46,8 @@
                 "Health-RI is the Dutch health care initiative to build an integrated health data infrastructure for research and innovation.";
         <http://healthdataportal.eu/ns/health#publisherType>
                 <http://example.com/publisherType/undefined>;
+         <http://healthdataportal.eu/ns/health#trustedDataHolder>
+                "true"^^<http://www.w3.org/2001/XMLSchema#boolean>;  # Added this line
         <http://healthdataportal.eu/ns/health#retentionPeriod>
                 [ a               dct:PeriodOfTime;
                   rdfs:comment    "As stated in the CSI deliberation";

--- a/examples/dcat/dataset_health_no_blank.ttl
+++ b/examples/dcat/dataset_health_no_blank.ttl
@@ -51,6 +51,7 @@
     healthdcatap:populationCoverage "This example includes a very non-descript population" ;
     healthdcatap:publisherNote "Health-RI is the Dutch health care initiative to build an integrated health data infrastructure for research and innovation." ;
     healthdcatap:publisherType <http://example.com/publisherType/undefined> ;
+    healthdcatap:trustedDataHolder "true"^^xsd:boolean ;  # Added this line
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC> ;
     dct:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/DAILY> ;
     dct:conformsTo <http://www.wikidata.org/entity/Q19597236> ;


### PR DESCRIPTION
Trusted data holder was missing within HealthDCAT. Now it is added