### PR TITLE
Improve access check in dcat_dataset_show

### DIFF
--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -20,6 +20,8 @@ def dcat_dataset_show(context, data_dict):
 
     toolkit.check_access('dcat_dataset_show', context, data_dict)
 
+    toolkit.check_access('package_show', context, data_dict)
+
     dataset_dict = toolkit.get_action('package_show')(context, data_dict)
 
     serializer = RDFSerializer(profiles=data_dict.get('profiles'))


### PR DESCRIPTION
Currently, the `dcat_dataset_show` action only calls:

```python
toolkit.check_access('dcat_dataset_show', context, data_dict)
```

However, the `dcat_dataset_show` auth function always evaluates to `True`, which is generally correct for DCAT endpoints. The problem arises when requesting a private dataset in a serialized format (e.g., `.ttl`).

Since no access check is performed for `package_show`, the call to:

```python
dataset_dict = toolkit.get_action('package_show')(context, data_dict)
```

can raise an uncaught auth exception. This results in a **500 Internal Server Error**.

**Proposed Fix:**
Add a `package_show` access check before calling the action:

```python
toolkit.check_access('package_show', context, data_dict)
```

**Steps to Reproduce:**

1. Create a private dataset.
2. Try to access its Turtle representation (e.g., `dataset/{id}.ttl`).
3. Observe that a 500 error is raised.