### PR TITLE
Provide default language in Croissant JSON-LD context

### DIFF
--- a/ckanext/dcat/helpers.py
+++ b/ckanext/dcat/helpers.py
@@ -72,7 +72,7 @@ def structured_data(dataset_dict, profiles=None):
     return _get_serialization(dataset_dict, profiles, "jsonld")
 
 
-def croissant(dataset_dict, profiles=None):
+def croissant(dataset_dict, profiles=None, jsonld_context=None):
     """
     Returns a string containing the Croissant ML representation of the given
     dataset using the `croissant` profile.
@@ -82,8 +82,10 @@ def croissant(dataset_dict, profiles=None):
     if not profiles:
         profiles = config.get("ckanext.dcat.croissant.profiles", ["croissant"])
 
-    frame = {"@context": JSONLD_CONTEXT, "@type": "sc:Dataset"}
+    context = jsonld_context or JSONLD_CONTEXT
+
+    frame = {"@context": context, "@type": "sc:Dataset"}
 
     return _get_serialization(
-        dataset_dict, profiles, "jsonld", context=JSONLD_CONTEXT, frame=frame
+        dataset_dict, profiles, "jsonld", context=context, frame=frame
     )

--- a/ckanext/dcat/profiles/croissant.py
+++ b/ckanext/dcat/profiles/croissant.py
@@ -24,6 +24,7 @@ SCHEMA = Namespace("https://schema.org/")
 
 JSONLD_CONTEXT = {
     "@vocab": "https://schema.org/",
+    "@language": config.get("ckan.locale_default"),
     "sc": "https://schema.org/",
     "cr": "http://mlcommons.org/croissant/",
     "rai": "http://mlcommons.org/croissant/RAI/",

--- a/ckanext/dcat/tests/test_blueprints.py
+++ b/ckanext/dcat/tests/test_blueprints.py
@@ -612,8 +612,8 @@ class TestCroissant():
         response = app.get(url)
 
         assert '<script type="application/ld+json">' in response.body
-        assert '"description": "test description"' in response.body
-        assert '"conformsTo": "http://mlcommons.org/croissant/1.0"' in response.body
+        assert '"@value": "test description"' in response.body
+        assert '"@value": "http://mlcommons.org/croissant/1.0"' in response.body
 
     @pytest.mark.ckan_config('ckan.plugins', 'dcat croissant')
     def test_croissant_metadata_endpoint(self, app):
@@ -627,8 +627,8 @@ class TestCroissant():
         response = app.get(url)
         croissant_dict = json.loads(response.body)
 
-        assert croissant_dict["description"] == "test description"
-        assert croissant_dict["conformsTo"] == "http://mlcommons.org/croissant/1.0"
+        assert croissant_dict["description"] == {"@value": "test description"}
+        assert croissant_dict["conformsTo"] == {"@value": "http://mlcommons.org/croissant/1.0"}
 
 
 @pytest.mark.usefixtures("with_plugins", "clean_db", "clean_index")


### PR DESCRIPTION
This was to fixed failures caused by the new version of the croissant package (introduced by https://github.com/mlcommons/croissant/pull/932), but it seems like a good thing to do anyway.

Sadly this means that the output generated from rdflib changes, from this:

```
"description": "Test description"
```

to this:

```
"description": {
    "@value": "Test description"
}
```

While this is a bit less human readable is perfectly valid JSON-LD, and it will probably align better with multilingual metadata.