### PR TITLE
[#359] Fix redirect from /dataset to /dataset_series

### DIFF
--- a/ckanext/dcat/blueprints.py
+++ b/ckanext/dcat/blueprints.py
@@ -36,8 +36,9 @@ if endpoints_enabled():
                       view_func=read_catalog)
 
     # TODO: Generalize for all dataset types
-    dcat.add_url_rule('/dataset_series/<_id>.<_format>', view_func=read_dataset)
-    dcat.add_url_rule('/dataset/<_id>.<_format>', view_func=read_dataset)
+    dcat.add_url_rule('/dataset_series/<_id>.<_format>', view_func=read_dataset, endpoint="read_dataset_series")
+    dcat.add_url_rule('/dataset/<_id>.<_format>', view_func=read_dataset, endpoint="read_dataset")
+
 
 
 if toolkit.asbool(config.get(utils.ENABLE_CONTENT_NEGOTIATION_CONFIG)):

--- a/ckanext/dcat/tests/test_blueprints.py
+++ b/ckanext/dcat/tests/test_blueprints.py
@@ -66,6 +66,16 @@ class TestEndpoints():
         assert dcat_dataset['title'] == dataset['title']
         assert dcat_dataset['notes'] == dataset['notes']
 
+    def test_dataset_default_no_redirects(self, app):
+
+        dataset = factories.Dataset(
+            notes='Test dataset'
+        )
+
+        url = url_for('dcat.read_dataset', _id=dataset['name'], _format='rdf')
+
+        assert url.startswith('/dataset/')
+
     def test_dataset_default_private(self, app):
         user = factories.UserWithToken()
         org = factories.Organization(users=[{"name": user["name"], "capacity": "admin"}])


### PR DESCRIPTION
Fixes #359 
The combination of two url rules pointing to the same view function plus using `url_defaults` in the blueprint made that Flask always redirected to one "canonical" URL (the first one defined). Defining different endpoints for each rule solves the issue.