### PR TITLE
Fix: use DCAT.version on DCAT AP v3 

### DIFF
--- a/ckanext/dcat/profiles/euro_dcat_ap_3.py
+++ b/ckanext/dcat/profiles/euro_dcat_ap_3.py
@@ -31,6 +31,13 @@ class EuropeanDCATAP3Profile(EuropeanDCATAP2Profile, EuropeanDCATAPSchemingProfi
         dataset_dict = self._parse_dataset_v2_scheming(dataset_dict, dataset_ref)
 
         # DCAT AP v3: hasVersion
+        dataset_dict = self._parse_dataset_v3(dataset_dict, dataset_ref)
+
+        return dataset_dict
+
+    def self._parse_dataset_v3(dataset_dict, dataset_ref):
+
+        # hasVersion
         values = self._object_value_list(dataset_ref, DCAT.hasVersion)
         if values:
             dataset_dict["has_version"] = values
@@ -51,11 +58,6 @@ class EuropeanDCATAP3Profile(EuropeanDCATAP2Profile, EuropeanDCATAPSchemingProfi
         # DCAT AP v3 properties also applied to higher versions
         self._graph_from_dataset_v3(dataset_dict, dataset_ref)
 
-        # DCAT AP v3: List triples
-        items = [
-            ("has_version", DCAT.hasVersion, None, URIRefOrLiteral),
-        ]
-        self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
 
     def graph_from_catalog(self, catalog_dict, catalog_ref):
 
@@ -70,6 +72,13 @@ class EuropeanDCATAP3Profile(EuropeanDCATAP2Profile, EuropeanDCATAPSchemingProfi
             dataset_series = True
             self.g.remove((dataset_ref, RDF.type, None))
             self.g.add((dataset_ref, RDF.type, DCAT.DatasetSeries))
+
+        # hasVersion
+        items = [
+            ("has_version", DCAT.hasVersion, None, URIRefOrLiteral),
+        ]
+        self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
+
 
         # byteSize decimal -> nonNegativeInteger
         for subject, predicate, object in self.g.triples((None, DCAT.byteSize, None)):

--- a/ckanext/dcat/profiles/euro_dcat_ap_3.py
+++ b/ckanext/dcat/profiles/euro_dcat_ap_3.py
@@ -6,6 +6,7 @@ from ckanext.dcat.profiles import (
     SKOS,
     ADMS,
     RDF,
+    OWL,
 )
 
 from .base import URIRefOrLiteral
@@ -35,7 +36,12 @@ class EuropeanDCATAP3Profile(EuropeanDCATAP2Profile, EuropeanDCATAPSchemingProfi
 
         return dataset_dict
 
-    def self._parse_dataset_v3(dataset_dict, dataset_ref):
+    def _parse_dataset_v3(self, dataset_dict, dataset_ref):
+
+        # version
+        value = self._object_value(dataset_ref, DCAT.version)
+        if value:
+            dataset_dict["version"] = value
 
         # hasVersion
         values = self._object_value_list(dataset_ref, DCAT.hasVersion)
@@ -58,7 +64,6 @@ class EuropeanDCATAP3Profile(EuropeanDCATAP2Profile, EuropeanDCATAPSchemingProfi
         # DCAT AP v3 properties also applied to higher versions
         self._graph_from_dataset_v3(dataset_dict, dataset_ref)
 
-
     def graph_from_catalog(self, catalog_dict, catalog_ref):
 
         self._graph_from_catalog_base(catalog_dict, catalog_ref)
@@ -73,12 +78,21 @@ class EuropeanDCATAP3Profile(EuropeanDCATAP2Profile, EuropeanDCATAPSchemingProfi
             self.g.remove((dataset_ref, RDF.type, None))
             self.g.add((dataset_ref, RDF.type, DCAT.DatasetSeries))
 
+        # version own:versionInfo -> dcat:version
+        self.g.remove((dataset_ref, OWL.versionInfo, None))
+        self._add_triple_from_dict(
+            dataset_dict,
+            dataset_ref,
+            DCAT.version,
+            "version",
+            _type=Literal,
+        )
+
         # hasVersion
         items = [
             ("has_version", DCAT.hasVersion, None, URIRefOrLiteral),
         ]
         self._add_list_triples_from_dict(dataset_dict, dataset_ref, items)
-
 
         # byteSize decimal -> nonNegativeInteger
         for subject, predicate, object in self.g.triples((None, DCAT.byteSize, None)):

--- a/ckanext/dcat/tests/profiles/dcat_ap_3/test_euro_dcatap_3_profile_serialize.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap_3/test_euro_dcatap_3_profile_serialize.py
@@ -68,7 +68,7 @@ class TestEuroDCATAP3ProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, RDF.type, DCAT.Dataset)
         assert self._triple(g, dataset_ref, DCT.title, dataset["title"])
         assert self._triple(g, dataset_ref, DCT.description, dataset["notes"])
-        assert self._triple(g, dataset_ref, OWL.versionInfo, dataset["version"])
+        assert self._triple(g, dataset_ref, DCAT.version, dataset["version"])
 
         # Standard fields
         assert self._triple(g, dataset_ref, DCT.identifier, dataset["identifier"])

--- a/ckanext/dcat/tests/profiles/dcat_us_3/test_dcat_us_3_profile_serialize.py
+++ b/ckanext/dcat/tests/profiles/dcat_us_3/test_dcat_us_3_profile_serialize.py
@@ -69,7 +69,7 @@ class TestDCATUS3ProfileSerializeDataset(BaseSerializeTest):
         assert self._triple(g, dataset_ref, RDF.type, DCAT.Dataset)
         assert self._triple(g, dataset_ref, DCT.title, dataset["title"])
         assert self._triple(g, dataset_ref, DCT.description, dataset["notes"])
-        assert self._triple(g, dataset_ref, OWL.versionInfo, dataset["version"])
+        assert self._triple(g, dataset_ref, DCAT.version, dataset["version"])
 
         # Standard fields
         assert self._triple(g, dataset_ref, DCT.identifier, dataset["identifier"])


### PR DESCRIPTION
The v3 profile was still using the old OWL.versionInfo property