### PR TITLE
fix: fallback to GET when HEAD request returns non-2xx response

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -67,7 +67,9 @@ class DCATHarvester(HarvesterBase):
             did_get = False
             r = session.head(url)
 
-            if r.status_code == 405 or r.status_code == 400:
+            # Some servers respond with 400 or 404 to HEAD requests, even if the resource exists. 
+            # In that case we want to try a GET request before giving up.
+            if not r.ok: 
                 r = session.get(url, stream=True)
                 did_get = True
             r.raise_for_status()


### PR DESCRIPTION
fix: fallback to GET when HEAD request returns non-2xx response

Some servers respond with 400 or 404 to HEAD requests even if the
resource exists. Replace explicit 400/405 status code checks with
a broader `not r.ok` condition to handle all non-successful responses
and retry with GET before giving up.

